### PR TITLE
added captive dns service

### DIFF
--- a/components/captivedns/captivedns.c
+++ b/components/captivedns/captivedns.c
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2017
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#include "luartos.h"
+
+#if LUA_USE_HTTP
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+#include "lwip/dns.h"
+#include "lwip/ip_addr.h"
+#include "lwip/udp.h"
+#include "lwip/pbuf.h"
+
+#include "esp_wifi_types.h"
+#include "tcpip_adapter.h"
+#include <sys/driver.h>
+#include <sys/panic.h>
+#include <esp_wifi.h>
+
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+#include <dirent.h>
+#include <sys/syslog.h>
+
+#define PORT           53
+
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
+
+#define DNS_QR_QUERY 0
+#define DNS_QR_RESPONSE 1
+#define DNS_OPCODE_QUERY 0
+
+struct DNSHeader
+{
+  uint16_t ID;               // identification number
+  unsigned char RD : 1;      // recursion desired
+  unsigned char TC : 1;      // truncated message
+  unsigned char AA : 1;      // authoritive answer
+  unsigned char OPCode : 4;  // message_type
+  unsigned char QR : 1;      // query/response flag
+  unsigned char RCode : 4;   // response code
+  unsigned char Z : 3;       // its z! reserved
+  unsigned char RA : 1;      // recursion available
+  uint16_t QDCount;          // number of question entries
+  uint16_t ANCount;          // number of answer entries
+  uint16_t NSCount;          // number of authority entries
+  uint16_t ARCount;          // number of resource entries
+};
+
+static tcpip_adapter_ip_info_t esp_info;
+static struct udp_pcb *captivedns_pcb;
+static u8_t captivedns_pcb_refcount;
+static void captivedns_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);
+driver_error_t *wifi_check_error(esp_err_t error);
+
+/** Ensure captivedns PCB is allocated and bound */
+static err_t
+captivedns_inc_pcb_refcount(void)
+{
+  if(captivedns_pcb_refcount == 0) {
+    LWIP_ASSERT("captivedns_inc_pcb_refcount(): memory leak", captivedns_pcb == NULL);
+
+    /* allocate UDP PCB */
+    captivedns_pcb = udp_new();
+
+    if(captivedns_pcb == NULL) {
+      return ERR_MEM;
+    }
+
+    /* set up local port for the pcb -> listen on all interfaces on all src/dest IPs */
+    udp_bind(captivedns_pcb, IP_ADDR_ANY, PORT);
+    udp_recv(captivedns_pcb, captivedns_recv, NULL);
+  }
+
+  captivedns_pcb_refcount++;
+
+  return ERR_OK;
+}
+
+/** Free captivedns PCB if the last netif stops using it */
+static void
+captivedns_dec_pcb_refcount(void)
+{
+  LWIP_ASSERT("captivedns_pcb_refcount(): refcount error", (captivedns_pcb_refcount > 0));
+  captivedns_pcb_refcount--;
+
+  if(captivedns_pcb_refcount == 0) {
+    udp_remove(captivedns_pcb);
+    captivedns_pcb = NULL;
+  }
+}
+
+/**
+ * In case of an incoming dns message, trigger the state machine
+ */
+static void
+captivedns_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port)
+{
+  struct netif *netif = ip_current_input_netif();
+  struct DNSHeader* dnsHeader = (struct DNSHeader*)p->payload;
+
+  if (dnsHeader->QR == DNS_QR_QUERY && dnsHeader->OPCode == DNS_OPCODE_QUERY &&
+      /* request only contains one question */
+      ntohs(dnsHeader->QDCount) == 1 && dnsHeader->ANCount == 0 &&
+      dnsHeader->NSCount == 0 && dnsHeader->ARCount == 0
+      /* request only contains one question */
+     ) {
+
+      dnsHeader->QR = DNS_QR_RESPONSE;
+      dnsHeader->ANCount = dnsHeader->QDCount;
+
+      struct pbuf *p_out;
+      p_out = pbuf_alloc(PBUF_TRANSPORT, p->len + 16, PBUF_RAM);
+      pbuf_take(p_out, p->payload, p->len); //cannot use tot_len here
+
+      u16_t position = p->len - 1;
+      pbuf_put_at(p_out, ++position, (uint8_t)192); // answer name is a pointer
+      pbuf_put_at(p_out, ++position, (uint8_t)12);  // pointer to offset at 0x00c
+
+      pbuf_put_at(p_out, ++position, (uint8_t)0);   // 0x0001  answer is type A query (host address)
+      pbuf_put_at(p_out, ++position, (uint8_t)1);
+
+      pbuf_put_at(p_out, ++position, (uint8_t)0);   // 0x0001 answer is class IN (internet address)
+      pbuf_put_at(p_out, ++position, (uint8_t)1);
+
+      pbuf_put_at(p_out, ++position, (uint8_t)0);   // fixed TTL of zero
+      pbuf_put_at(p_out, ++position, (uint8_t)0);
+      pbuf_put_at(p_out, ++position, (uint8_t)0);
+      pbuf_put_at(p_out, ++position, (uint8_t)0);
+
+      pbuf_put_at(p_out, ++position, (uint8_t)0);   // length of RData is 4 bytes (because, in this case, RData is IPv4)
+      pbuf_put_at(p_out, ++position, (uint8_t)4);
+
+      //esp32 ip addr
+      pbuf_put_at(p_out, ++position, (uint8_t)ip4_addr1(&esp_info.ip));
+      pbuf_put_at(p_out, ++position, (uint8_t)ip4_addr2(&esp_info.ip));
+      pbuf_put_at(p_out, ++position, (uint8_t)ip4_addr3(&esp_info.ip));
+      pbuf_put_at(p_out, ++position, (uint8_t)ip4_addr4(&esp_info.ip));
+
+      udp_sendto_if(captivedns_pcb, p_out, addr, port, netif);
+      pbuf_free(p_out);
+  }
+
+  pbuf_free(p);
+}
+
+void captivedns_start() {
+	driver_error_t *error;
+
+	uint8_t mode;
+	if ((error = wifi_check_error(esp_wifi_get_mode((wifi_mode_t*)&mode)))) return; //FIXME
+
+	if (mode == WIFI_MODE_STA) {
+		return; //FIXME should report reason
+	}
+
+	// Get WIFI IF info
+	if ((error = wifi_check_error(tcpip_adapter_get_ip_info(ESP_IF_WIFI_AP, &esp_info)))) return; //FIXME
+
+	captivedns_inc_pcb_refcount();
+}
+
+void captivedns_stop() {
+	captivedns_dec_pcb_refcount();
+}
+
+#endif

--- a/components/captivedns/component.mk
+++ b/components/captivedns/component.mk
@@ -1,0 +1,6 @@
+#
+# Component Makefile
+#
+
+COMPONENT_SRCDIRS := . 
+COMPONENT_ADD_INCLUDEDIRS := . 

--- a/components/lua_rtos/Lua/modules/net.c
+++ b/components/lua_rtos/Lua/modules/net.c
@@ -41,6 +41,7 @@
 #include "net_service_sntp.inc"
 #include "net_service_http.inc"
 #include "net_service_curl.inc"
+#include "net_service_captivedns.inc"
 #include "net_ssh.inc"
 
 #include <stdint.h>
@@ -239,6 +240,7 @@ static const LUA_REG_TYPE service_map[] = {
 	{ LSTRKEY( "sntp" ), LROVAL ( sntp_map ) },
 #if LUA_USE_HTTP
 	{ LSTRKEY( "http" ), LROVAL ( http_map ) },
+	{ LSTRKEY( "captivedns" ), LROVAL ( captivedns_map ) },
 #endif
 };
 

--- a/components/lua_rtos/Lua/modules/net_service_captivedns.inc
+++ b/components/lua_rtos/Lua/modules/net_service_captivedns.inc
@@ -1,0 +1,70 @@
+/*
+ * Lua RTOS, lua captivedns module
+ *
+ * Copyright (C) 2015 - 2017
+ *
+ * All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both that the copyright notice and this
+ * permission notice and warranty disclaimer appear in supporting
+ * documentation, and that the name of the author not be used in
+ * advertising or publicity pertaining to distribution of the
+ * software without specific, written prior permission.
+ *
+ * The author disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall the author be liable for any
+ * special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
+
+#include "luartos.h"
+
+#if LUA_USE_HTTP
+
+#include "net.h"
+
+#include "lwip/err.h"
+
+#include <drivers/net.h>
+
+extern void captivedns_start();
+extern void captivedns_stop();
+
+static int lcaptivedns_start(lua_State* L) {
+	driver_error_t *error;
+
+	if ((error = net_check_connectivity())) {
+    	return luaL_driver_error(L, error);
+	}
+
+	captivedns_start();
+
+	return 0;
+}
+
+static int lcaptivedns_stop(lua_State* L) {
+	driver_error_t *error;
+
+	if ((error = net_check_connectivity())) {
+    	return luaL_driver_error(L, error);
+	}
+
+	captivedns_stop();
+
+	return 0;
+}
+
+static const LUA_REG_TYPE captivedns_map[] = {
+    { LSTRKEY( "start" ),	 LFUNCVAL( lcaptivedns_start   ) },
+    { LSTRKEY( "stop"  ),	 LFUNCVAL( lcaptivedns_stop    ) },
+	{ LNILKEY, LNILVAL }
+};
+
+#endif

--- a/components/lua_rtos/drivers/wifi.c
+++ b/components/lua_rtos/drivers/wifi.c
@@ -227,8 +227,8 @@ driver_error_t *wifi_setup(wifi_mode_t mode, char *ssid, char *password, int pow
 
 	// Sanity checks
 	if (mode == WIFI_MODE_AP) {
-		if (strlen(password) < 8) {
-			return driver_operation_error(WIFI_DRIVER, WIFI_ERR_WIFI_PASSWORD, "length must be greater or equal to 8");
+		if (*password && strlen(password) < 8) {
+			return driver_operation_error(WIFI_DRIVER, WIFI_ERR_WIFI_PASSWORD, "if provided the password must have more than 7 characters");
 		}
 	}
 


### PR DESCRIPTION
needs to be started explicitly using net.service.captivedns.start()
error handling in captivedns_start needs to be implemented, see FIXME.