### PR TITLE
Fix warnings created by commit e65bbf7

### DIFF
--- a/components/lua_rtos/syscalls/__wrap_opendir.c
+++ b/components/lua_rtos/syscalls/__wrap_opendir.c
@@ -19,7 +19,7 @@ DIR* __wrap_opendir(const char* name) {
 
 	if (!name || !*name) {
 		errno = ENOENT;
-		return -1;
+		return (DIR*)-1;
 	}
 
 	ppath = mount_resolve_to_physical(name);

--- a/components/lua_rtos/syscalls/__wrap_readdir.c
+++ b/components/lua_rtos/syscalls/__wrap_readdir.c
@@ -19,7 +19,7 @@ DIR* __wrap_readdir(const char* name) {
 
 	if (!name || !*name) {
 		errno = ENOENT;
-		return -1;
+		return (DIR*)-1;
 	}
 
 	ppath = mount_resolve_to_physical(name);


### PR DESCRIPTION
Cast return values to DIR* to eliminate warnings