### PR TITLE
wifi stability fix

### DIFF
--- a/components/lua_rtos/drivers/wifi.c
+++ b/components/lua_rtos/drivers/wifi.c
@@ -225,13 +225,6 @@ driver_error_t *wifi_setup(wifi_mode_t mode, char *ssid, char *password, int pow
 
 	status_clear(STATUS_WIFI_SETUP);
 
-	// Sanity checks
-	if (mode == WIFI_MODE_AP) {
-		if (strlen(password) < 8) {
-			return driver_operation_error(WIFI_DRIVER, WIFI_ERR_WIFI_PASSWORD, "length must be greater or equal to 8");
-		}
-	}
-
 	// Attach wifi driver
 	if ((error = wifi_init(mode))) return error;
 

--- a/components/lua_rtos/pthread/pthread.c
+++ b/components/lua_rtos/pthread/pthread.c
@@ -383,7 +383,7 @@ int _pthread_suspend(pthread_t id) {
         return res;
     }
     
-    // Stop
+    // Suspend
     vTaskSuspend(thread->task);
     
     return 0;
@@ -400,7 +400,7 @@ int _pthread_resume(pthread_t id) {
         return res;
     }
         
-    // Stop
+    // Resume
     vTaskResume(thread->task);
 
     return 0;


### PR DESCRIPTION
this will make wifi more stable when switching between sta, ap and scan.
also the httpsrv will be started only once and will be ended on stop().
unimportant change: updated two comment lines in pthread.c

should add to the wiki that a call to net.wf.scan() will deactivate a previously active soft-AP.
probably we will want to change this in the future (e.g. re-activate the soft-AP automatically), but that would mean to keep the AP config data lying around somewhere in the driver level.