### PR TITLE
the0ne/stabilize net and mqtt

### DIFF
--- a/components/lua_rtos/Lua/modules/mqtt.c
+++ b/components/lua_rtos/Lua/modules/mqtt.c
@@ -245,8 +245,9 @@ static int lmqtt_connected( lua_State* L ) {
     
     rc = MQTTClient_connected(mqtt->client);
 
-		lua_pushinteger( L, rc == MQTTCLIENT_SUCCESS ? 1 : 0 );
-    return 1;
+    lua_pushboolean( L, rc == MQTTCLIENT_SUCCESS ? 1 : 0 );
+
+	return 1;
 }
 
 static int lmqtt_connect( lua_State* L ) {

--- a/components/lua_rtos/Lua/modules/net.c
+++ b/components/lua_rtos/Lua/modules/net.c
@@ -237,7 +237,7 @@ static int lnet_stat(lua_State* L) {
 }
 
 static int lnet_connected(lua_State* L) {
-  lua_pushinteger( L, NETWORK_AVAILABLE() );
+  lua_pushboolean( L, NETWORK_AVAILABLE() );
   return 1;
 }
 

--- a/components/lua_rtos/Lua/modules/net.c
+++ b/components/lua_rtos/Lua/modules/net.c
@@ -236,6 +236,11 @@ static int lnet_stat(lua_State* L) {
 	return table;
 }
 
+static int lnet_connected(lua_State* L) {
+  lua_pushinteger( L, NETWORK_AVAILABLE() );
+  return 1;
+}
+
 static const LUA_REG_TYPE service_map[] = {
 	{ LSTRKEY( "sntp" ), LROVAL ( sntp_map ) },
 #if LUA_USE_HTTP
@@ -246,6 +251,7 @@ static const LUA_REG_TYPE service_map[] = {
 
 static const LUA_REG_TYPE net_map[] = {
 	{ LSTRKEY( "stat" ), LFUNCVAL ( lnet_stat ) },
+	{ LSTRKEY( "connected" ), LFUNCVAL ( lnet_connected ) },
 	{ LSTRKEY( "lookup" ), LFUNCVAL ( lnet_lookup ) },
 	{ LSTRKEY( "packip" ), LFUNCVAL ( lnet_packip ) },
 	{ LSTRKEY( "unpackip" ), LFUNCVAL ( lnet_unpackip ) },

--- a/components/lua_rtos/drivers/gdisplay.c
+++ b/components/lua_rtos/drivers/gdisplay.c
@@ -1,5 +1,7 @@
 #include "sdkconfig.h"
 
+#if LUA_RTOS_LUA_USE_GDISPLAY
+
 #include "esp_attr.h"
 
 #include "freertos/FreeRTOS.h"
@@ -356,3 +358,5 @@ void gdisplay_ll_set_orientation(uint8_t orientation) {
 		buff_pixels = caps.width * caps.height;
 	}
 }
+
+#endif

--- a/components/lua_rtos/drivers/gdisplay.c
+++ b/components/lua_rtos/drivers/gdisplay.c
@@ -1,6 +1,6 @@
 #include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include "esp_attr.h"
 

--- a/components/lua_rtos/drivers/gdisplay.h
+++ b/components/lua_rtos/drivers/gdisplay.h
@@ -1,9 +1,10 @@
 #ifndef DRIVERS_GDISPLAY_H_
 #define DRIVERS_GDISPLAY_H_
 
+#include "sdkconfig.h"
 #include <stdint.h>
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #define DELAY 0x80
 

--- a/components/lua_rtos/drivers/gdisplay.h
+++ b/components/lua_rtos/drivers/gdisplay.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#if LUA_RTOS_LUA_USE_GDISPLAY
+
 #define DELAY 0x80
 
 typedef struct {
@@ -69,5 +71,7 @@ void gdisplay_ll_on();
 void gdisplay_ll_off();
 void gdisplay_ll_invert(uint8_t on);
 void gdisplay_ll_set_orientation(uint8_t m);
+
+#endif
 
 #endif /* DRIVERS_GDISPLAY_H_ */

--- a/components/lua_rtos/drivers/ili9341.c
+++ b/components/lua_rtos/drivers/ili9341.c
@@ -38,7 +38,7 @@
 
 #include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/components/lua_rtos/drivers/ili9341.c
+++ b/components/lua_rtos/drivers/ili9341.c
@@ -37,6 +37,9 @@
  */
 
 #include "sdkconfig.h"
+
+#if LUA_RTOS_LUA_USE_GDISPLAY
+
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -422,3 +425,5 @@ void ili9341_tp_get(int *x, int *y, int *z, uint8_t raw) {
 }
 
 DRIVER_REGISTER(ILI9341,ili9341,NULL,NULL,NULL);
+
+#endif

--- a/components/lua_rtos/drivers/ili9341.h
+++ b/components/lua_rtos/drivers/ili9341.h
@@ -39,6 +39,8 @@
 #ifndef ILI9341_H
 #define	ILI9341_H
 
+#if LUA_RTOS_LUA_USE_GDISPLAY
+
 // Display constants
 #define DELAY 0x80
 
@@ -106,5 +108,7 @@ void ili9341_set_orientation(uint8_t m);
 
 void ili9341_tp_get(int *x, int *y, int *z, uint8_t raw);
 void ili9341_tp_set_cal(int calx, int caly);
+
+#endif
 
 #endif	/* ILI9341_H */

--- a/components/lua_rtos/drivers/ili9341.h
+++ b/components/lua_rtos/drivers/ili9341.h
@@ -39,7 +39,9 @@
 #ifndef ILI9341_H
 #define	ILI9341_H
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#include "sdkconfig.h"
+
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 // Display constants
 #define DELAY 0x80

--- a/components/lua_rtos/drivers/net.h
+++ b/components/lua_rtos/drivers/net.h
@@ -52,8 +52,6 @@
 #define evSPI_ETH_CONNECTED 	     ( 1 << 3 )
 #define evSPI_ETH_CANT_CONNECT       ( 1 << 4 )
 
-#define NETWORK_AVAILABLE() (status_get(STATUS_WIFI_CONNECTED) || status_get(STATUS_SPI_ETH_CONNECTED))
-
 typedef struct {
     ip4_addr_t ip;
     ip4_addr_t netmask;

--- a/components/lua_rtos/drivers/pcd8544.c
+++ b/components/lua_rtos/drivers/pcd8544.c
@@ -29,6 +29,8 @@
 
 #include "sdkconfig.h"
 
+#if LUA_RTOS_LUA_USE_GDISPLAY
+
 #include "freertos/FreeRTOS.h"
 
 #include <string.h>
@@ -230,3 +232,5 @@ void pcd8544_invert(uint8_t on) {
 }
 
 DRIVER_REGISTER(PCD8544,pcd8544,NULL,NULL,NULL);
+
+#endif

--- a/components/lua_rtos/drivers/pcd8544.c
+++ b/components/lua_rtos/drivers/pcd8544.c
@@ -29,7 +29,7 @@
 
 #include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include "freertos/FreeRTOS.h"
 

--- a/components/lua_rtos/drivers/pcd8544.h
+++ b/components/lua_rtos/drivers/pcd8544.h
@@ -30,9 +30,9 @@
 #ifndef PCD8544_H_
 #define PCD8544_H_
 
-#include "luartos.h"
+#include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include <stdint.h>
 

--- a/components/lua_rtos/drivers/pcd8544.h
+++ b/components/lua_rtos/drivers/pcd8544.h
@@ -32,6 +32,8 @@
 
 #include "luartos.h"
 
+#if LUA_RTOS_LUA_USE_GDISPLAY
+
 #include <stdint.h>
 
 #include <sys/driver.h>
@@ -70,5 +72,7 @@ void pcd8544_set_orientation(uint8_t m);
 void pcd8544_on();
 void pcd8544_off();
 void pcd8544_invert(uint8_t on);
+
+#endif
 
 #endif /* PCD8544_H_ */

--- a/components/lua_rtos/drivers/st7735.c
+++ b/components/lua_rtos/drivers/st7735.c
@@ -42,7 +42,7 @@
 
 #include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/components/lua_rtos/drivers/st7735.c
+++ b/components/lua_rtos/drivers/st7735.c
@@ -41,6 +41,9 @@
  */
 
 #include "sdkconfig.h"
+
+#if LUA_RTOS_LUA_USE_GDISPLAY
+
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -506,3 +509,5 @@ void st7735_clear(uint32_t color) {
 }
 
 DRIVER_REGISTER(ST7735,st7735,NULL,NULL,NULL);
+
+#endif

--- a/components/lua_rtos/drivers/st7735.h
+++ b/components/lua_rtos/drivers/st7735.h
@@ -43,7 +43,9 @@
 #ifndef ST7735S_H
 #define	ST7735S_H
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#include "sdkconfig.h"
+
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #define ST7735_BUFFER 1920
 

--- a/components/lua_rtos/drivers/st7735.h
+++ b/components/lua_rtos/drivers/st7735.h
@@ -43,6 +43,8 @@
 #ifndef ST7735S_H
 #define	ST7735S_H
 
+#if LUA_RTOS_LUA_USE_GDISPLAY
+
 #define ST7735_BUFFER 1920
 
 // Display constants
@@ -177,5 +179,7 @@ void st7735_invert(uint8_t on);
 void st7735_addr_window(uint8_t write, int x0, int y0, int x1, int y1);
 void st7735_color(uint16_t *color, uint32_t len);
 void st7735_clear(uint32_t color);
+
+#endif
 
 #endif	/* ST7735S_H */

--- a/components/lua_rtos/sys/status.h
+++ b/components/lua_rtos/sys/status.h
@@ -38,6 +38,8 @@
 
 #include <stdint.h>
 
+#define NETWORK_AVAILABLE() (status_get(STATUS_WIFI_CONNECTED) || status_get(STATUS_SPI_ETH_CONNECTED))
+
 #define STATUS_SYSCALLS_INITED	       0x0000
 #define STATUS_LUA_RUNNING			   0x0001
 #define STATUS_LUA_INTERPRETER  	   0x0002

--- a/components/mqtt/MQTTClient.h
+++ b/components/mqtt/MQTTClient.h
@@ -765,6 +765,15 @@ DLLExport int MQTTClient_unsubscribe(MQTTClient handle, const char* topic);
 DLLExport int MQTTClient_unsubscribeMany(MQTTClient handle, int count, char* const* topic);
 
 /** 
+  * This function returns if a connection is established
+  * @param handle A valid client handle from a successful call to
+  * MQTTClient_create().
+  * @return ::MQTTCLIENT_SUCCESS if the client is connected.
+  * An error code is returned if there is no connection.
+  */
+DLLExport int MQTTClient_connected(MQTTClient handle);
+
+/** 
   * This function attempts to publish a message to a given topic (see also
   * MQTTClient_publishMessage()). An ::MQTTClient_deliveryToken is issued when 
   * this function returns successfully. If the client application needs to 

--- a/components/mqtt/MQTTProtocolClient.c
+++ b/components/mqtt/MQTTProtocolClient.c
@@ -736,14 +736,14 @@ void MQTTProtocol_freeMessageList(List* msgList)
 * @param dest_size the size of the memory pointed to by dest: copy no more than this -1 (allow for null).  Must be >= 1
 * @return the destination string pointer
 */
-char* MQTTStrncpy(char *dest, const char *src, size_t dest_size)
+char* MQTTStrncpyInt(char *dest, const char *src, size_t dest_size, bool warn_truncate)
 {
   size_t count = dest_size;
   char *temp = dest;
 
   FUNC_ENTRY; 
-  if (dest_size < strlen(src))
-    Log(TRACE_MIN, -1, "the src string is truncated");
+  if (dest_size < strlen(src) && 0 != warn_truncate)
+    Log(TRACE_MIN, -1, "the src string is truncated from %i to %i - src string was: %s", strlen(src), dest_size, src);
 
   /* We must copy only the first (dest_size - 1) bytes */
   while (count > 1 && (*temp++ = *src++))
@@ -755,6 +755,10 @@ char* MQTTStrncpy(char *dest, const char *src, size_t dest_size)
   return dest;
 }
 
+char* MQTTStrncpy(char *dest, const char *src, size_t dest_size)
+{
+	return MQTTStrncpyInt(dest, src, dest_size, 1);
+}
 
 /**
 * Duplicate a string, safely, allocating space on the heap

--- a/components/mqtt/MQTTProtocolClient.h
+++ b/components/mqtt/MQTTProtocolClient.h
@@ -48,6 +48,7 @@ void MQTTProtocol_freeClient(Clients* client);
 void MQTTProtocol_emptyMessageList(List* msgList);
 void MQTTProtocol_freeMessageList(List* msgList);
 
-char* MQTTStrncpy(char *dest, const char* src, size_t num);
+char* MQTTStrncpyInt(char *dest, const char *src, size_t dest_size, bool warn_truncate);
+char* MQTTStrncpy(char *dest, const char* src, size_t dest_size);
 char* MQTTStrdup(const char* src);
 #endif

--- a/components/mqtt/MQTTProtocolOut.c
+++ b/components/mqtt/MQTTProtocolOut.c
@@ -61,7 +61,7 @@ char* MQTTProtocol_addressPort(const char* uri, int* port)
 		size_t addr_len = colon_pos - uri;
 		buf = malloc(addr_len + 1);
 		*port = atoi(colon_pos + 1);
-		MQTTStrncpy(buf, uri, addr_len+1);
+		MQTTStrncpyInt(buf, uri, addr_len+1, 0);
 	}
 	else
 		*port = DEFAULT_PORT;
@@ -97,8 +97,9 @@ int MQTTProtocol_connect(const char* ip_address, Clients* aClient, int MQTTVersi
 
 	addr = MQTTProtocol_addressPort(ip_address, &port);
 	rc = Socket_new(addr, port, &(aClient->net.socket));
-	if (rc == EINPROGRESS || rc == EWOULDBLOCK)
+	if (rc == EINPROGRESS || rc == EWOULDBLOCK) {
 		aClient->connect_state = 1; /* TCP connect called - wait for connect completion */
+	}
 	else if (rc == 0)
 	{	/* TCP connect completed. If SSL, send SSL connect */
 #if defined(OPENSSL)

--- a/components/mqtt/Socket.h
+++ b/components/mqtt/Socket.h
@@ -65,6 +65,7 @@
 #endif
 /** must be the same as SOCKETBUFFER_INTERRUPTED */
 #define TCPSOCKET_INTERRUPTED -22
+#define TCPSOCKET_INTERRUPTED_FINAL -23
 #define SSL_FATAL -3
 
 #if !defined(INET6_ADDRSTRLEN)


### PR DESCRIPTION
further stabilized mqtt

mqtt will try to auto-reconnect if the mqtt connection is lost and a network connection is available
lua scripts can now use net.connected() (instead of e.g. checking ip against 0.0.0.0)

lua scripts can now check mqtt.connected() (and e.g. dump the old mqtt object in that case) so that the script can hold a valid mqtt connection all the time -> it's then *very* fast to send data
also to reliably receive data it's necessary the script can make sure mqtt is still connected