### PR TITLE
httpsrv: net notification on connectivity change

### DIFF
--- a/components/captivedns/captivedns.c
+++ b/components/captivedns/captivedns.c
@@ -200,4 +200,8 @@ void captivedns_stop() {
 	captivedns_dec_pcb_refcount();
 }
 
+int captivedns_running() {
+	return (captivedns_pcb_refcount>0 ? 1 : 0);
+}
+
 #endif


### PR DESCRIPTION
added net callback for httpsrv.
httpsrv will recognize net changes and re-query the current ip.
if captivedns is running when wifi is switched to STA then captivedns
will be stopped.
if captivedns had been auto-stopped and wifi is switched back to AP then
captivedns will be auto-started.

added log messages for some possible init errors in httpsrv.