### PR TITLE
Add mac address to wifi stat table.

### DIFF
--- a/components/lua_rtos/Lua/modules/net_wifi.inc
+++ b/components/lua_rtos/Lua/modules/net_wifi.inc
@@ -203,7 +203,7 @@ static int lwifi_stat(lua_State* L) {
 		printf("   ip address %s netmask %s\r\n", ipa, maska);
 		printf("   gw address %s\r\n\r\n", gwa);
 	} else {
-		char tmp[17];
+		char tmp[18];
 
 		lua_createtable(L, 0, 4);
 
@@ -221,6 +221,15 @@ static int lwifi_stat(lua_State* L) {
 		sprintf(tmp, IPSTR, ip4_addr1_16(&info.netmask),ip4_addr2_16(&info.netmask),ip4_addr3_16(&info.netmask),ip4_addr4_16(&info.netmask));
 		lua_pushstring(L, tmp);
 		lua_setfield (L, -2, "netmask");
+
+		sprintf(tmp, "%02x:%02x:%02x:%02x:%02x:%02x",
+			info.mac[0],info.mac[1],
+			info.mac[2],info.mac[3],
+			info.mac[4],info.mac[5]
+		);
+		lua_pushstring(L, tmp);
+		lua_setfield (L, -2, "mac");
+
 	}
 
 	return table;


### PR DESCRIPTION
I needed a unique identifier for MQTT topics, and the MAC address is an obvious candidate.