### PR TITLE
the0ne/mqtt

### DIFF
--- a/components/lua_rtos/Lua/modules/loslib_adds.inc
+++ b/components/lua_rtos/Lua/modules/loslib_adds.inc
@@ -268,8 +268,54 @@ static int os_mkdir (lua_State *L) {
 	return luaL_fileresult(L, mkdir(path, 0) == 0, path);
 }
 
+inline int fnmatch(/*const*/ char *pattern, const char *string, int flags) {
+	int i=0;
+	int si=strlen(string)-1;
+	int pi=strlen(pattern)-1;
+
+	(void) flags;
+
+	// the following does support just one asterisk
+	while (string[i]!=0 && pattern[i]!=0 && pattern[i]!='*' && string[i]==pattern[i]) {
+		i++;
+	}
+	if (pattern[i]=='*' || (string[i]==0 && pattern[i]==0))
+	{
+		if (pattern[i+1]!=0) {					
+			//need to check strlen(pattern)-i chars from the back...
+			while (string[si]!=0 && pattern[pi]!=0 && string[si]==pattern[pi] && pi>i) {
+				si--; pi--;
+			}
+			if (pi==i) {
+				return 0;
+			}
+		}
+		else {
+			return 0;
+		}
+	}
+
+	// the following does support just exactly two asterisk:
+	// one at the very start plus one at the very end
+	pi=strlen(pattern)-1;
+	if (pattern[0]=='*' && pattern[pi]=='*') {
+		// yes we could copy the pattern each time instead of this hack...
+		pattern[pi]=0;
+		pattern++;
+		const char* result = strstr(string, pattern);
+		pattern--;
+		pattern[pi]='*';
+		if (NULL!=result) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
 static int os_ls (lua_State *L) {
 	const char *path = luaL_optstring(L, 1, NULL);
+	char *filename = NULL;
 	DIR *dir = NULL;
 	struct dirent *ent;
 	char type;
@@ -280,7 +326,32 @@ static int os_ls (lua_State *L) {
 	struct stat sb;
 	struct tm *tm_info;
 
-	// If path is not present get the current directory as path
+	if (path) {
+		dir = opendir(path);
+		if (!dir) {
+			//search back to the last dir name
+			filename = (char*)path + strlen(path) - 1;
+			while (filename > path && *filename!=0 && *filename!='/') {
+				filename--;
+			}
+			//string given is not a valid path
+			//so try to find a matching file
+			//in the current folder
+			if (filename==path) {
+				filename = (char*)path;
+				path = NULL;
+			}
+			else if (*filename == '/') {
+				*filename = 0; //will cut off the filename from the path
+				filename++;
+			}
+		}
+		else {
+			closedir(dir);
+		}
+	}
+
+	// If path is not present (at all or any more) get the current directory as path
 	if (!path) {
 		if (!getcwd(cpath, PATH_MAX)) {
 			return luaL_fileresult(L, 0, cpath);
@@ -321,13 +392,10 @@ static int os_ls (lua_State *L) {
 		} else {
 			strcpy(size, "       -");
 		}
-		
-		printf("%c\t%s\t%s\t%s\n",
-			type,
-			size,
-			tbuffer,
-			ent->d_name
-		);
+
+		if (filename==NULL || 0==fnmatch(filename, ent->d_name, 0)) { //our implementation above does support only a subset
+			printf("%c\t%s\t%s\t%s\n", type, size, tbuffer, ent->d_name);
+		}
 	}
 
 	//tty_unlock();

--- a/components/lua_rtos/Lua/modules/mqtt.c
+++ b/components/lua_rtos/Lua/modules/mqtt.c
@@ -273,7 +273,12 @@ static int lmqtt_connect( lua_State* L ) {
     conn_opts.cleansession = 0;
     conn_opts.username = user;
     conn_opts.password = password;
-    ssl_opts.enableServerCertAuth = 0;
+
+    /* temporarily set via MQTTClient_SSLOptions_initializer
+    ssl_opts.enableServerCertAuth = 1;
+    ssl_opts.trustStore = "/examples/lua/letsencrypt.pem";
+    */
+
     conn_opts.ssl = &ssl_opts;
 
     bcopy(&conn_opts, &mqtt->conn_opts, sizeof(MQTTClient_connectOptions));

--- a/components/lua_rtos/Lua/modules/mqtt.c
+++ b/components/lua_rtos/Lua/modules/mqtt.c
@@ -74,8 +74,6 @@ DRIVER_REGISTER_BEGIN(MQTT,mqtt,NULL,NULL,NULL);
 DRIVER_REGISTER_END(MQTT,mqtt,NULL,NULL,NULL);
 
 static int client_inited = 0;
-//needs to be persistent for connectionLost MQTTClient_connect to work
-static MQTTClient_SSLOptions ssl_opts = MQTTClient_SSLOptions_initializer;
 
 typedef struct {
     char *topic;
@@ -91,6 +89,7 @@ typedef struct {
     MQTTClient client;
     
     mqtt_subs_callback *callbacks;
+    const char *ca_file;
 
     int secure;
 } mqtt_userdata;
@@ -198,13 +197,15 @@ static int lmqtt_client( lua_State* L ){
     size_t lenClientId, lenHost;
     mqtt_userdata *mqtt;
     char url[250];
-        
-    clientId = luaL_checklstring( L, 1, &lenClientId );
-    host = luaL_checklstring( L, 2, &lenHost );
+
+    clientId = luaL_checklstring( L, 1, &lenClientId ); //is being strdup'd in MQTTClient_create
+    host = luaL_checklstring( L, 2, &lenHost ); //url is being strdup'd in MQTTClient_connectURI
     port = luaL_checkinteger( L, 3 );
 
     luaL_checktype(L, 4, LUA_TBOOLEAN);
     secure = lua_toboolean( L, 4 );
+
+    const char *ca_file = luaL_optstring( L, 5, NULL );
     
     // Allocate mqtt structure and initialize
     mqtt = (mqtt_userdata *)lua_newuserdata(L, sizeof(mqtt_userdata));
@@ -212,6 +213,7 @@ static int lmqtt_client( lua_State* L ){
     mqtt->client = NULL;
     mqtt->callbacks = NULL;
     mqtt->secure = secure;
+    mqtt->ca_file = (ca_file ? strdup(ca_file):NULL); //save for use during mqtt_connect
     mtx_init(&mqtt->callback_mtx, NULL, NULL, 0);
     
     // Calculate uri
@@ -222,6 +224,7 @@ static int lmqtt_client( lua_State* L ){
         client_inited = 1;
     }
     
+    //url is being strdup'd in MQTTClient_connectURI
     rc = MQTTClient_create(&mqtt->client, url, clientId, MQTTCLIENT_PERSISTENCE_NONE, NULL);
     if (rc < 0){
       return luaL_exception(L, LUA_MQTT_ERR_CANT_CREATE_CLIENT);
@@ -271,15 +274,13 @@ static int lmqtt_connect( lua_State* L ) {
     conn_opts.keepAliveInterval = 60;
     conn_opts.reliable = 0;
     conn_opts.cleansession = 0;
-    conn_opts.username = user;
-    conn_opts.password = password;
+    conn_opts.username = user; //is being strdup'd in MQTTClient_connectURI
+    conn_opts.password = password; //is being strdup'd in MQTTClient_connectURI
 
-    /* temporarily set via MQTTClient_SSLOptions_initializer
-    ssl_opts.enableServerCertAuth = 1;
-    ssl_opts.trustStore = "/examples/lua/letsencrypt.pem";
-    */
-
-    conn_opts.ssl = &ssl_opts;
+    MQTTClient_SSLOptions ssl_opts = MQTTClient_SSLOptions_initializer;
+    ssl_opts.trustStore = mqtt->ca_file; //is being malloc'd in MQTTClient_connectURI
+    ssl_opts.enableServerCertAuth = (ssl_opts.trustStore != NULL);
+    conn_opts.ssl = &ssl_opts; //is being malloc'd in MQTTClient_connectURI
 
     bcopy(&conn_opts, &mqtt->conn_opts, sizeof(MQTTClient_connectOptions));
 

--- a/components/mqtt/MQTTClient.c
+++ b/components/mqtt/MQTTClient.c
@@ -1082,8 +1082,8 @@ int MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectOptions* options,
 	}
 #endif
 
-	m->c->username = options->username;
-	m->c->password = options->password;
+	m->c->username = MQTTStrdup(options->username);
+	m->c->password = MQTTStrdup(options->password);
 	m->c->retryInterval = options->retryInterval;
 
 	if (options->struct_version >= 3)

--- a/components/mqtt/MQTTClient.c
+++ b/components/mqtt/MQTTClient.c
@@ -1212,7 +1212,7 @@ int MQTTClient_disconnect1(MQTTClient handle, int timeout, int call_connection_l
 		rc = MQTTCLIENT_DISCONNECTED;
 		goto exit;
 	}
-	was_connected = m->c->connected; /* should be 1 */
+	was_connected = (m->c->connected && m->c->connect_state==3); /* should be 1 */
 	if (m->c->connected != 0)
 	{
 		start = MQTTClient_start_clock();

--- a/components/mqtt/MQTTClient.h
+++ b/components/mqtt/MQTTClient.h
@@ -495,7 +495,7 @@ typedef struct
   
 } MQTTClient_SSLOptions;
 
-#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 0, NULL, NULL, NULL, NULL, NULL, 1 }
+#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 0, "/examples/lua/letsencrypt.pem", NULL, NULL, NULL, NULL, 1 }
 
 /**
  * MQTTClient_connectOptions defines several settings that control the way the

--- a/components/mqtt/MQTTClient.h
+++ b/components/mqtt/MQTTClient.h
@@ -464,7 +464,7 @@ typedef struct
 	const char struct_id[4];
 	/** The version number of this structure.  Must be 0 */
 	int struct_version;	
-	
+
 	/** The file in PEM format containing the public digital certificates trusted by the client. */
 	const char* trustStore;
 
@@ -472,14 +472,14 @@ typedef struct
 	* the client's private key. 
 	*/
 	const char* keyStore;
-	
+
 	/** If not included in the sslKeyStore, this setting points to the file in PEM format containing
 	* the client's private key.
 	*/
 	const char* privateKey;
 	/** The password to load the client's privateKey if encrypted. */
 	const char* privateKeyPassword;
- 
+
 	/**
 	* The list of cipher suites that the client will present to the server during the SSL handshake. For a 
 	* full explanation of the cipher list format, please see the OpenSSL on-line documentation:
@@ -490,12 +490,12 @@ typedef struct
 	*/
 	const char* enabledCipherSuites;
 
-    /** True/False option to enable verification of the server certificate **/
-    int enableServerCertAuth;
-  
+	/** True/False option to enable verification of the server certificate **/
+	int enableServerCertAuth;
+
 } MQTTClient_SSLOptions;
 
-#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 0, "/examples/lua/letsencrypt.pem", NULL, NULL, NULL, NULL, 1 }
+#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 0, NULL, NULL, NULL, NULL, NULL, 0 }
 
 /**
  * MQTTClient_connectOptions defines several settings that control the way the


### PR DESCRIPTION
mqtt.client now has a fifth parameter ca_file (optional) which is a pem encoded local file.
the server will be validated against that pem and the ssl connection will only succeed if the server matches the ca_file cert or if no ca_file cert is given.