### PR TITLE
Make boards/boards.py PY3 compatible.

### DIFF
--- a/boards/boards.py
+++ b/boards/boards.py
@@ -1,7 +1,6 @@
 import json
 import sys
 
-i = 1
 board = 0
 prop = "description"
 
@@ -17,17 +16,15 @@ with open('boards/boards.json') as json_data:
     d = json.load(json_data)
     json_data.close()
     
-for row in d:
+for i, row in enumerate(d, 1):
     if ((board == 0) or (board == i)):
         if (board == 0):
-            sys.stdout.write(`i`.rjust(2) + ": ")
-            sys.stdout.write(row[prop])
+            sys.stdout.write('%2d: %s' % (i, row[prop]))
         else:
             sys.stdout.write(row[prop])
         
         if (board == 0):
              sys.stdout.write("\\")
-        
-    i = i + 1
     
 sys.stdout.flush()
+


### PR DESCRIPTION
The backtick support (to get object representation) in Python has been deprecated quite a long ago and it has been removed in Python 3. The repr function should be used instead.

I've used a different approach: string formatting. The resulting output is exactly the same as before. I've also replaced the `i` variable incremented in the loop with an `enumerate` function, which generates 2-element tuples containing incrementing value and the item for each item in the collection.

This won't be compatible with Python versions before 2.6 because of the second argument to `enumerate` function, which was added in 2.6. I don't know if there's a need to support earlier versions but I'd assume that there's not as Python 2.6 has been around for a really long time.