### PR TITLE
fix for issue #126 "rm directory error"

### DIFF
--- a/components/sys/vfs/spiffs.c
+++ b/components/sys/vfs/spiffs.c
@@ -191,7 +191,7 @@ static void check_path(const char *path, uint8_t *base_is_dir,
 
         if (!strncmp(fpath, (const char *) e.name,
                 min(strlen((char * )e.name), strlen(fpath) - 1))) {
-            if (strcmp(fpath, (const char *) e.name)) {
+            if (strlen((const char *) e.name) >= strlen(fpath) && strcmp(fpath, (const char *) e.name)) {
                 file_num++;
             }
         }


### PR DESCRIPTION
the patch makes sure that the parent directory is no longer
errornously counted as a file inside the target directory

this occurred for folders starting with "." (dot)

check_path starting with /foo/.bar
check_path checking /foo/.bar/. against /foo/.
<== this "/foo/." was wrongly counted as a file inside /foo/.bar
check_path checking /foo/.bar/. against /foo/.bar/.