### PR TITLE
Bug with relative paths in mklfs

### DIFF
--- a/components/mklfs/src/mklfs.c
+++ b/components/mklfs/src/mklfs.c
@@ -288,12 +288,10 @@ int main(int argc, char **argv) {
 		return -1;
 	}
 
-	chdir(src);
-	compact(".");
+	compact(src);
 
-	FILE *img;
+	FILE *img = fopen(dst, "wb+");
 
-	img = fopen(dst, "wb+");
 	if (!img) {
 		fprintf(stderr, "can't create image file: errno=%d (%s)\r\n", errno, strerror(errno));
 		return -1;


### PR DESCRIPTION
Bug: if user uses a relative path for the final image, then the path will be built relative to the packaging directory. Fixed.

Using always the same working directory makes mklfs calls idempotent