### PR TITLE
Use default value when reading from non-existing namespace

### DIFF
--- a/components/lua/modules/sys/nvs.c
+++ b/components/lua/modules/sys/nvs.c
@@ -213,6 +213,12 @@ static int l_nvs_read(lua_State *L) {
     // Open
     err = nvs_open(nspace, NVS_READONLY, &handle_to_settings);
     if (err != ESP_OK) {
+    
+        if (err == ESP_ERR_NVS_NOT_FOUND && total == 3) {
+            lua_pushvalue(L, 3);
+            return 1;
+        }
+
     	nvs_error(L, err);
     }
 


### PR DESCRIPTION
Use default provided to nvs.read(namespace,key,default) when reading from non-existing namespace, instead of error-ing with 'non existing key' 