### PR TITLE
fix editor behaviour in out-of-memory scenario

### DIFF
--- a/components/lua/modules/sys/loslib_adds.inc
+++ b/components/lua/modules/sys/loslib_adds.inc
@@ -145,14 +145,21 @@ static int os_edit (lua_State *L) {
     }
 
     // Create file if does not exists
-    FILE *fp = fopen(path, "a");
+    bool bCreated = false;
+    FILE *fp = fopen(path, "r");
     if (!fp) {
-        return luaL_fileresult(L, 0, path);
+        bCreated = true;
+        fp = fopen(path, "a");
+        if (!fp) {
+            return luaL_fileresult(L, 0, path);
+        }
     }
     fclose(fp);
   
     char* lua_argv[] = {(char *)"edit", (char *)path, NULL};
-    edit_main(2, lua_argv);
+    if (1 == edit_main(2, lua_argv) && bCreated) {
+        unlink(path);
+    }
     console_clear();
     return 0;
 }

--- a/components/sys/editor/edit.c
+++ b/components/sys/editor/edit.c
@@ -2074,7 +2074,7 @@ int edit_main(int argc, char *argv[]) {
     if (rc < 0 && errno == ENOENT) rc = new_file(ed, argv[i]);
     if (rc < 0) {
       perror(argv[i]);
-      return 0;
+      return 1;
     }
   }
   if (env.current == NULL) {


### PR DESCRIPTION
if the memory is too low, the editor will exit with error
but leave a previously-not-existing but newly created file in the file system.

now, in case of error, we make sure to unlink the file again.