### PR TITLE
re-enable building of the experimental openvpn component

### DIFF
--- a/components/dropbear/compat.c
+++ b/components/dropbear/compat.c
@@ -156,6 +156,7 @@ strlcat(dst, src, siz)
 #endif /* HAVE_STRLCAT */
 
 #ifndef HAVE_DAEMON
+#if !__XTENSA__
 /* From NetBSD - daemonise a process */
 
 int daemon(int nochdir, int noclose) {
@@ -186,6 +187,7 @@ int daemon(int nochdir, int noclose) {
 	}
 	return 0;
 }
+#endif
 #endif /* HAVE_DAEMON */
 
 #ifndef HAVE_BASENAME

--- a/components/lua/modules/luasocket/socket.h
+++ b/components/lua/modules/luasocket/socket.h
@@ -20,6 +20,14 @@
 #include "usocket.h"
 #endif
 
+#if __XTENSA__
+    // rename socket_bind to luasocket_bind so that it won't interfere
+    // with the socket_bind function that openvpn comes with
+    #define socket_bind luasocket_bind
+    // make sure that all luasocket source files that use socket_bind
+    // include this header file directly or indirectly
+#endif
+
 /*=========================================================================*\
 * The connect and accept functions accept a timeout and their
 * implementations are somewhat complicated. We chose to move

--- a/components/lua/modules/net/net_service_openvpn.inc
+++ b/components/lua/modules/net/net_service_openvpn.inc
@@ -62,62 +62,63 @@ u8_t volatile _openvpn_should_stop = 0;
 u8_t volatile _openvpn_running = 0;
 
 static void *openvpn_thread(void *arg) {
-	// Wait for network
+    // Wait for network
     if (!wait_for_network(20000)) {
         lua_State* L = (lua_State*)arg;
         luaL_exception(L, NET_ERR_NOT_AVAILABLE);
     }
 
-	delay(1000);
+    delay(1000);
 
-	char* argv[] = {
-			"openvpn",
-			"--config", CONFIG_LUA_RTOS_OPENVPN_CONFIG_FILE,
-			"--ifconfig-nowarn",
-			"--single-session"
-	};
+    char* argv[] = {
+            "openvpn",
+            "--config",
+            CONFIG_LUA_RTOS_OPENVPN_CONFIG_FILE,
+            "--ifconfig-nowarn",
+            "--single-session"
+    };
 
-	_openvpn_running = 1;
-	openvpn(5, argv);
-	_openvpn_running = 0;
+    _openvpn_running = 1;
+    openvpn(5, argv);
+    _openvpn_running = 0;
 
-	return NULL;
+    return NULL;
 }
 
 static int lopenvpn_service_start(lua_State* L) {
-	pthread_t thread;
-	pthread_attr_t attr;
+    pthread_t thread;
+    pthread_attr_t attr;
 
     _openvpn_should_stop = 0;
 
-	pthread_attr_init(&attr);
+    pthread_attr_init(&attr);
     pthread_attr_setstacksize(&attr, 8192);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
     if (pthread_create(&thread, &attr, openvpn_thread, L)) {
-    	return 0;
-	}
+        return 0;
+    }
 
     pthread_setname_np(thread, "openvpn");
 
-	return 0;
+    return 0;
 }
 
 static int lopenvpn_service_stop(lua_State* L) {
     _openvpn_should_stop = 1;
-	return 0;
+    return 0;
 }
 
 static int lopenvpn_service_running( lua_State* L ) {
-	lua_pushboolean(L, _openvpn_running);
-	return 1;
+    lua_pushboolean(L, _openvpn_running);
+    return 1;
 }
 
 static const LUA_REG_TYPE openvpn_map[] = {
-	{ LSTRKEY("start"  ), LFUNCVAL( lopenvpn_service_start   ) },
-	{ LSTRKEY("stop"   ), LFUNCVAL( lopenvpn_service_stop    ) },
-	{ LSTRKEY("running"), LFUNCVAL( lopenvpn_service_running ) },
-	{ LNILKEY,LNILVAL }
+    { LSTRKEY("start"  ), LFUNCVAL( lopenvpn_service_start   ) },
+    { LSTRKEY("stop"   ), LFUNCVAL( lopenvpn_service_stop    ) },
+    { LSTRKEY("running"), LFUNCVAL( lopenvpn_service_running ) },
+    { LNILKEY,LNILVAL }
 };
 
 #endif

--- a/components/lua/modules/net/net_service_openvpn.inc
+++ b/components/lua/modules/net/net_service_openvpn.inc
@@ -58,11 +58,13 @@
 #include <drivers/net.h>
 
 int openvpn(int argc, char *argv[]);
-static u8_t volatile _openvpn_running = 0;
+u8_t volatile _openvpn_should_stop = 0;
+u8_t volatile _openvpn_running = 0;
 
 static void *openvpn_thread(void *arg) {
 	// Wait for network
     if (!wait_for_network(20000)) {
+        lua_State* L = (lua_State*)arg;
         luaL_exception(L, NET_ERR_NOT_AVAILABLE);
     }
 
@@ -86,12 +88,13 @@ static int lopenvpn_service_start(lua_State* L) {
 	pthread_t thread;
 	pthread_attr_t attr;
 
-	pthread_attr_init(&attr);
+    _openvpn_should_stop = 0;
 
+	pthread_attr_init(&attr);
     pthread_attr_setstacksize(&attr, 8192);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
-    if (pthread_create(&thread, &attr, openvpn_thread, NULL)) {
+    if (pthread_create(&thread, &attr, openvpn_thread, L)) {
     	return 0;
 	}
 
@@ -101,6 +104,7 @@ static int lopenvpn_service_start(lua_State* L) {
 }
 
 static int lopenvpn_service_stop(lua_State* L) {
+    _openvpn_should_stop = 1;
 	return 0;
 }
 

--- a/components/openvpn/config.h
+++ b/components/openvpn/config.h
@@ -45,7 +45,11 @@
 // OpenVPN is executed into a task, so when calling to exit function
 // simply delete current task
 #define exit(e) \
-	vTaskDelete(NULL);
+    { \
+      extern u8_t volatile _openvpn_running; \
+      _openvpn_running = 0; \
+      vTaskDelete(NULL); \
+    }
 
 // srandom is missing in esp-idf, so use srand instead
 #define srandom(s) srand(s)

--- a/components/openvpn/config.h
+++ b/components/openvpn/config.h
@@ -36,11 +36,9 @@
 
 #include <string.h>
 
-#include "../compat/include/linux/in6.h"
 #include "lwip/sockets.h"
 #include "lwip/netdb.h"
-
-#include "linux/netdb.h"
+#include <compat/include/linux/in6.h>
 
 #include "tcpip_adapter.h"
 
@@ -51,6 +49,9 @@
 
 // srandom is missing in esp-idf, so use srand instead
 #define srandom(s) srand(s)
+
+// openvpn uses small letters but lwip uses capitals
+#define lwip_socket_offset LWIP_SOCKET_OFFSET
 
 #define PACKAGE_NAME "openvpn"
 #define PACKAGE "openvpn"

--- a/components/openvpn/src/openvpn/error.c
+++ b/components/openvpn/src/openvpn/error.c
@@ -777,10 +777,6 @@ openvpn_exit(const int status)
         }
     }
 
-#if __XTENSA__
-    extern u8_t volatile _openvpn_running;
-    _openvpn_running = 0;
-#endif
     exit(status);
 }
 

--- a/components/openvpn/src/openvpn/error.c
+++ b/components/openvpn/src/openvpn/error.c
@@ -777,6 +777,10 @@ openvpn_exit(const int status)
         }
     }
 
+#if __XTENSA__
+    extern u8_t volatile _openvpn_running;
+    _openvpn_running = 0;
+#endif
     exit(status);
 }
 

--- a/components/openvpn/src/openvpn/sig.c
+++ b/components/openvpn/src/openvpn/sig.c
@@ -435,10 +435,22 @@ ignore_restart_signals(struct context *c)
     return ret;
 }
 
+#if __XTENSA__
+extern u8_t volatile _openvpn_should_stop;
+#endif
+
 bool
 process_signal(struct context *c)
 {
     bool ret = true;
+
+#if __XTENSA__
+    if (1 == _openvpn_should_stop)
+    {
+        _openvpn_should_stop = 0;
+        c->sig->signal_received = SIGTERM; //make openvpn exit it's main loop
+    }
+#endif
 
     if (ignore_restart_signals(c))
     {

--- a/components/sys/luartos.h
+++ b/components/sys/luartos.h
@@ -134,7 +134,7 @@
 #endif
 
 #if CONFIG_FREERTOS_THREAD_LOCAL_STORAGE_POINTERS <= 1
-#error "Please, review the 'Number of thread local storage pointers' settings in kconfig. Must be >= 2."
+#error "Please review the 'Number of thread local storage pointers' settings in kconfig. Must be >= 2."
 #endif
 
 #define THREAD_LOCAL_STORAGE_POINTER_ID (CONFIG_FREERTOS_THREAD_LOCAL_STORAGE_POINTERS - 1)
@@ -142,7 +142,10 @@
 // OpenVPN
 #if CONFIG_LUA_RTOS_USE_OPENVPN
 #if !CONFIG_MBEDTLS_BLOWFISH_C
-#error "OpenVPM requires CONFIG_MBEDTLS_BLOWFISH_C = 1. Please activate it with make menuconfig, enabling option in mbedTLS -> Symmetric Ciphers -> Blowfish block cipher."
+#error "OpenVPN requires CONFIG_MBEDTLS_BLOWFISH_C = 1. Please activate it with make menuconfig, enabling option in mbedTLS -> Symmetric Ciphers -> Blowfish block cipher."
+#endif
+#if !CONFIG_MBEDTLS_DES_C
+#error "OpenVPN requires CONFIG_MBEDTLS_DES_C = 1. Please activate it with make menuconfig, enabling option in mbedTLS -> Symmetric Ciphers -> DES block cipher (legacy, insecure)."
 #endif
 #endif
 


### PR DESCRIPTION
see commit 376700d for the actual implementation.
please note that stopping openvpn can take quite a while as we're currently _not_ actively "interrupting" the openvpn process: only once openvpn gets active again by itself, it _will_ exit - e.g. after some inactivity timeout, connection interruption, etc.

regarding this PR please note that 07de0be does not change source code but only formatting. however, *both* commits should be merged.

regarding the openvpn component itself the notes and limitations of https://github.com/whitecatboard/Lua-RTOS-ESP32/commit/707d75430411440a700124de36c44bcc5f8b5ab0 still apply