### PR TITLE
remove openvpn memory leaks + add net.tu.stat()

### DIFF
--- a/components/lua/modules/net/net.c
+++ b/components/lua/modules/net/net.c
@@ -336,6 +336,31 @@ static int lnet_stat(lua_State* L) {
     }
 #endif
 
+#if CONFIG_LUA_RTOS_LUA_USE_NET && CONFIG_LUA_RTOS_USE_OPENVPN
+extern u8_t volatile _openvpn_running;
+if (_openvpn_running) {
+    lua_pushinteger(L, interfaces++);
+
+    // Call wf.stat
+    lua_getglobal(L, "net");
+    lua_getfield(L, -1, "tu");
+    lua_getfield(L, -1, "stat");
+    lua_pushboolean(L, table);
+
+    if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+        return luaL_error(L, lua_tostring(L, -1));
+    }
+
+    if (table) {
+        lua_remove(L, 4);
+        lua_remove(L, 4);
+        lua_settable(L, -3);
+    } else {
+        lua_settop(L, 0);
+    }
+}
+#endif
+
     return table;
 }
 
@@ -398,7 +423,7 @@ static const LUA_REG_TYPE service_map[] = {
 };
 
 static const LUA_REG_TYPE net_map[] = {
-    { LSTRKEY( "stat" ), LFUNCVAL ( lnet_stat ) },
+    { LSTRKEY( "stat" ),      LFUNCVAL ( lnet_stat ) },
     { LSTRKEY( "connected" ), LFUNCVAL ( lnet_connected ) },
     { LSTRKEY( "lookup" ),    LFUNCVAL ( lnet_lookup ) },
     { LSTRKEY( "packip" ),    LFUNCVAL ( lnet_packip ) },
@@ -420,6 +445,10 @@ static const LUA_REG_TYPE net_map[] = {
 
 #if CONFIG_LUA_RTOS_ETH_HW_TYPE_RMII && CONFIG_LUA_RTOS_LUA_USE_NET
     { LSTRKEY( "en" ), LROVAL ( eth_map ) },
+#endif
+
+#if CONFIG_LUA_RTOS_LUA_USE_NET && CONFIG_LUA_RTOS_USE_OPENVPN
+    { LSTRKEY( "tu" ), LROVAL ( tun_map ) },
 #endif
 
 #if CONFIG_LUA_RTOS_LUA_USE_CURL_NET

--- a/components/lua/modules/net/net_service_openvpn.inc
+++ b/components/lua/modules/net/net_service_openvpn.inc
@@ -68,7 +68,7 @@ static void *openvpn_thread(void *arg) {
         luaL_exception(L, NET_ERR_NOT_AVAILABLE);
     }
 
-    delay(1000);
+    delay(1000); //probably not required
 
     char* argv[] = {
             "openvpn",
@@ -114,11 +114,106 @@ static int lopenvpn_service_running( lua_State* L ) {
     return 1;
 }
 
+driver_error_t *tun_if_stat(ifconfig_t *info);
+
+static int lopenvpn_tun_stat(lua_State* L) {
+    ifconfig_t info;
+    driver_error_t *error;
+    u8_t table = 0;
+
+    // Check if user wants result as a table, or wants scan's result
+    // on the console
+    if (lua_gettop(L) == 1) {
+        luaL_checktype(L, 1, LUA_TBOOLEAN);
+        if (lua_toboolean(L, 1)) {
+            table = 1;
+        }
+    }
+
+    if ((error = tun_if_stat(&info))) {
+        return luaL_driver_error(L, error);
+    }
+
+    if (!table) {
+        char ipa[16];
+        char maska[16];
+        char gwa[16];
+
+        strcpy(ipa, inet_ntoa(info.ip));
+        strcpy(maska, inet_ntoa(info.netmask));
+        strcpy(gwa, inet_ntoa(info.gw));
+
+        printf(
+                "tu: mac address %02x:%02x:%02x:%02x:%02x:%02x\r\n",
+                info.mac[0],info.mac[1],
+                info.mac[2],info.mac[3],
+                info.mac[4],info.mac[5]
+        );
+
+        printf("   ip address %s netmask %s\r\n", ipa, maska);
+        printf("   gw address %s\r\n\r\n", gwa);
+    } else {
+        char tmp[18];
+
+        lua_createtable(L, 0, 4);
+
+        lua_pushstring(L, "tu");
+        lua_setfield (L, -2, "interface");
+
+        sprintf(tmp,"%d.%d.%d.%d", ip4_addr1_16(&info.ip),ip4_addr2_16(&info.ip),ip4_addr3_16(&info.ip),ip4_addr4_16(&info.ip));
+        lua_pushstring(L, tmp);
+        lua_setfield (L, -2, "ip");
+
+        sprintf(tmp,"%d.%d.%d.%d", ip4_addr1_16(&info.gw),ip4_addr2_16(&info.gw),ip4_addr3_16(&info.gw),ip4_addr4_16(&info.gw));
+        lua_pushstring(L, tmp);
+        lua_setfield (L, -2, "gw");
+
+        sprintf(tmp,"%d.%d.%d.%d", ip4_addr1_16(&info.netmask),ip4_addr2_16(&info.netmask),ip4_addr3_16(&info.netmask),ip4_addr4_16(&info.netmask));
+        lua_pushstring(L, tmp);
+        lua_setfield (L, -2, "netmask");
+
+        sprintf(tmp, "%02x:%02x:%02x:%02x:%02x:%02x",
+            info.mac[0],info.mac[1],
+            info.mac[2],info.mac[3],
+            info.mac[4],info.mac[5]
+        );
+        lua_pushstring(L, tmp);
+        lua_setfield (L, -2, "mac");
+    }
+
+    return table;
+}
+
+driver_error_t *tun_if_stat(ifconfig_t *info) {
+    tcpip_adapter_ip_info_t esp_info;
+    uint8_t mac[6] = {0,0,0,0,0,0};
+
+    // Get IP info
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_TUN, &esp_info);
+
+    // Get MAC info
+    tcpip_adapter_get_mac(TCPIP_ADAPTER_IF_TUN, mac);
+
+    // Copy info
+    info->gw = esp_info.gw;
+    info->ip = esp_info.ip;
+    info->netmask = esp_info.netmask;
+
+    memcpy(info->mac, mac, sizeof(mac));
+
+    return NULL;
+}
+
 static const LUA_REG_TYPE openvpn_map[] = {
     { LSTRKEY("start"  ), LFUNCVAL( lopenvpn_service_start   ) },
     { LSTRKEY("stop"   ), LFUNCVAL( lopenvpn_service_stop    ) },
     { LSTRKEY("running"), LFUNCVAL( lopenvpn_service_running ) },
     { LNILKEY,LNILVAL }
+};
+
+static const LUA_REG_TYPE tun_map[] = {
+    { LSTRKEY( "stat"  ),     LFUNCVAL( lopenvpn_tun_stat    ) },
+    { LNILKEY, LNILVAL }
 };
 
 #endif

--- a/components/openvpn/src/openvpn/tun.c
+++ b/components/openvpn/src/openvpn/tun.c
@@ -616,18 +616,18 @@ do_ifconfig(struct tuntap *tt,
         tcpip_adapter_ip_info_t ip_info;
 
         // To use tcpip_adapter_get_ip_info, first whe have to stop dhcp
-		tcpip_adapter_dhcpc_stop(TCPIP_ADAPTER_IF_TUN);
+        tcpip_adapter_dhcpc_stop(TCPIP_ADAPTER_IF_TUN);
 
-		// Get previous ip info
-		tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_TUN, &ip_info);
+        // Get previous ip info
+        tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_TUN, &ip_info);
 
-		// Update ip info
-    	ip_info.ip.addr = ntohl(tt->local);
-		ip_info.netmask.addr = ntohl(tt->remote_netmask);
-		ip_info.gw.addr = ntohl(tt->broadcast);
+        // Update ip info
+        ip_info.ip.addr = ntohl(tt->local);
+        ip_info.netmask.addr = ntohl(tt->remote_netmask);
+        ip_info.gw.addr = ntohl(tt->broadcast);
 
-		// Update ip information to tun adapter
-		tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_TUN, &ip_info);
+        // Update ip information to tun adapter
+        tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_TUN, &ip_info);
     }
 }
 
@@ -638,11 +638,16 @@ clear_tuntap(struct tuntap *tuntap)
     tuntap->fd = -1;
 }
 
+#if __XTENSA__
+void vfs_tun_register();
+#endif
+
 void
 open_tun(struct tuntap *tt)
 {
-	vfs_tun_register();
-
+#if __XTENSA__
+    vfs_tun_register();
+#endif
     tt->fd = open("/dev/tun", O_RDWR);
     tt->actual_name = string_alloc("tu", NULL);
 }
@@ -652,11 +657,10 @@ close_tun(struct tuntap *tt)
 {
     if (tt)
     {
-    	if (tt->fd >= 0) {
-    		close(tt->fd);
-    	}
-
-    	free(tt);
+        if (tt->fd >= 0) {
+            close(tt->fd);
+        }
+        free(tt);
     }
 }
 

--- a/components/sys/lwip/netif/tunif.c
+++ b/components/sys/lwip/netif/tunif.c
@@ -105,13 +105,14 @@ extern xQueueHandle tun_queue_rx;
 extern xQueueHandle tun_queue_tx;
 
 static struct netif *tun_netif;
+static TaskHandle_t xtask = 0; // the task itself
 
 void tunif_input(struct netif *netif);
 
 static void tun_task(void *args) {
-	for(;;) {
-		tunif_input(tun_netif);
-	}
+    for(;;) {
+        tunif_input(tun_netif);
+    }
 }
 
 /**
@@ -124,55 +125,55 @@ static void tun_task(void *args) {
  * @param netif the lwip network interface structure for this ethernetif
  */
 void tunif_input(struct netif *netif) {
-	struct pbuf *p;
-	err_t ok = ERR_OK;
+    struct pbuf *p;
+    err_t ok = ERR_OK;
 
-	/* move received packet into a new pbuf */
-	xQueueReceive(tun_queue_tx, &p, portMAX_DELAY);
+    if (tun_queue_tx) {
+        /* move received packet into a new pbuf */
+        xQueueReceive(tun_queue_tx, &p, portMAX_DELAY);
 
-	/* full packet send to tcpip_thread to process */
-	ok = netif->input(p, netif);
-	if (ok != ERR_OK) {
-		LWIP_DEBUGF(NETIF_DEBUG, ("ethernetif_input: IP input error\n"));
-		pbuf_free(p);
-	}
+        /* full packet send to tcpip_thread to process */
+        ok = netif->input(p, netif);
+        if (ok != ERR_OK) {
+            LWIP_DEBUGF(NETIF_DEBUG, ("ethernetif_input: IP input error\n"));
+            pbuf_free(p);
+        }
+    }
 }
 
 err_t tun_output(struct netif *netif, struct pbuf *p) {
-	struct pbuf *q;
-	struct pbuf *c;
+    struct pbuf *q;
+    struct pbuf *c;
 
 #if ETH_PAD_SIZE
-	pbuf_header(p, -ETH_PAD_SIZE); /* drop the padding word */
+    pbuf_header(p, -ETH_PAD_SIZE); /* drop the padding word */
 #endif
 
-	q = p;
-	if (q->len > 0) {
-		if (tun_queue_rx) {
-			c = pbuf_alloc(PBUF_RAW_TX, q->tot_len, PBUF_RAM);
-			if (c) {
-				pbuf_copy(c, q);
-			}
+    q = p;
+    if (q->len > 0) {
+        if (tun_queue_rx) {
+            c = pbuf_alloc(PBUF_RAW_TX, q->tot_len, PBUF_RAM);
+            if (c) {
+                pbuf_copy(c, q);
+            }
 
-			if (xQueueSend(tun_queue_rx, &c, portMAX_DELAY) == errQUEUE_FULL) {
-				pbuf_free(c);
-
-				return ERR_MEM;
-			}
-		}
-	}
+            if (xQueueSend(tun_queue_rx, &c, portMAX_DELAY) == errQUEUE_FULL) {
+                pbuf_free(c);
+                return ERR_MEM;
+            }
+        }
+    }
 
 #if ETH_PAD_SIZE
-	pbuf_header(p, ETH_PAD_SIZE); /* reclaim the padding word */
+    pbuf_header(p, ETH_PAD_SIZE); /* reclaim the padding word */
 #endif
 
-	LINK_STATS_INC(link.xmit);
-
-	return ERR_OK;
+    LINK_STATS_INC(link.xmit);
+    return ERR_OK;
 }
 
 static err_t etharp_tun_output(struct netif *netif, struct pbuf *q, const ip4_addr_t *ipaddr) {
-	return netif->linkoutput(netif, q);
+    return netif->linkoutput(netif, q);
 }
 
 /**
@@ -188,52 +189,54 @@ static err_t etharp_tun_output(struct netif *netif, struct pbuf *q, const ip4_ad
  *         any other err_t on error
  */
 err_t tunif_init(struct netif *netif) {
-	LWIP_ASSERT("netif != NULL", (netif != NULL));
+    LWIP_ASSERT("netif != NULL", (netif != NULL));
 
 #if LWIP_NETIF_HOSTNAME
-	/* Initialize interface hostname */
+    /* Initialize interface hostname */
 
 #if ESP_LWIP
-	netif->hostname = "espressif";
+    netif->hostname = "espressif";
 #else
-	netif->hostname = "lwip";
+    netif->hostname = "lwip";
 #endif
 
 #endif /* LWIP_NETIF_HOSTNAME */
 
-	/*
-	 * Initialize the snmp variables and counters inside the struct netif.
-	 * The last argument should be replaced with your link speed, in units
-	 * of bits per second.
-	 */
-	//NETIF_INIT_SNMP(netif, snmp_ifType_ethernet_csmacd, LINK_SPEED_OF_YOUR_NETIF_IN_BPS);
+    /*
+     * Initialize the snmp variables and counters inside the struct netif.
+     * The last argument should be replaced with your link speed, in units
+     * of bits per second.
+     */
+    NETIF_INIT_SNMP(netif, snmp_ifType_ethernet_csmacd, 100);
 
-	netif->name[0] = IFNAME0;
-	netif->name[1] = IFNAME1;
-	/* We directly use etharp_output() here to save a function call.
-	 * You can instead declare your own function an call etharp_output()
-	 * from it if you have to do some checks before sending (e.g. if link
-	 * is available...) */
-	netif->output = etharp_tun_output;
+    netif->name[0] = IFNAME0;
+    netif->name[1] = IFNAME1;
+    /* We directly use etharp_output() here to save a function call.
+     * You can instead declare your own function an call etharp_output()
+     * from it if you have to do some checks before sending (e.g. if link
+     * is available...) */
+    netif->output = etharp_tun_output;
 #if LWIP_IPV6
-	//netif->output_ip6 = ethip6_output;
+    //netif->output_ip6 = ethip6_output;
 #endif /* LWIP_IPV6 */
-	netif->linkoutput = tun_output;
+    netif->linkoutput = tun_output;
 
-	/* initialize the hardware */
-	netif->flags = 0;
-	netif->mtu = 1500;
-	netif->flags = NETIF_FLAG_LINK_UP | NETIF_FLAG_UP | NETIF_FLAG_UP;
+    /* initialize the hardware */
+    netif->flags = 0;
+    netif->mtu = 1500;
+    netif->flags = NETIF_FLAG_LINK_UP | NETIF_FLAG_UP | NETIF_FLAG_UP;
 
-	netif->hwaddr_len = ETHARP_HWADDR_LEN;
+    netif->hwaddr_len = ETHARP_HWADDR_LEN;
 
-	tun_netif = netif;
+    tun_netif = netif;
 
-    xTaskCreatePinnedToCore(tun_task, "tun", 1024, NULL, configMAX_PRIORITIES - 2, NULL, xPortGetCoreID());
+    if (xtask) {
+        vTaskDelete(xtask);
+        xtask = 0;
+    }
+    xTaskCreatePinnedToCore(tun_task, "tun", 1024, NULL, configMAX_PRIORITIES - 2, &xtask, xPortGetCoreID());
 
-	//enc424j600_init(netif);
-
-	return ERR_OK;
+    return ERR_OK;
 }
 
 #endif


### PR DESCRIPTION
memory leaks occurred for the "tun" thread and the "tun_queue_rx" and "tun_queue_tx" queues
whenever the client had manually or automatically (every few minutes) restarted the connection

please do **not** merge yet