### PR TITLE
fixed crash in ip_input

### DIFF
--- a/components/openvpn/src/openvpn/tun.c
+++ b/components/openvpn/src/openvpn/tun.c
@@ -660,6 +660,9 @@ close_tun(struct tuntap *tt)
         if (tt->fd >= 0) {
             close(tt->fd);
         }
+#if __XTENSA__
+        free(tt->actual_name);
+#endif
         free(tt);
     }
 }

--- a/components/sys/lwip/netif/tunif.c
+++ b/components/sys/lwip/netif/tunif.c
@@ -114,7 +114,7 @@ static void tun_task(void *args) {
     while(0 == _task_should_stop) {
         tunif_input(tun_netif);
     }
-    vTaskDelete(NULL);
+    _task_should_stop = 0;
 }
 
 /**
@@ -230,11 +230,12 @@ err_t tunif_init(struct netif *netif) {
 
     netif->hwaddr_len = ETHARP_HWADDR_LEN;
 
-    tun_netif = netif;
-
     if (xtask) {
         _task_should_stop = 1;
-        usleep(100); //wait some time for tunif_input to exit
+        while (1 == _task_should_stop) {
+          usleep(10000); // Sleep 10 msecs for tunif_input to exit - calls vTaskDelay
+        }
+        vTaskDelete(xtask);
     }
     _task_should_stop = 0;
     xTaskCreatePinnedToCore(tun_task, "tun", 1024, (void*)netif, configMAX_PRIORITIES - 2, &xtask, xPortGetCoreID());

--- a/components/sys/lwip/netif/tunif.c
+++ b/components/sys/lwip/netif/tunif.c
@@ -104,13 +104,13 @@
 extern xQueueHandle tun_queue_rx;
 extern xQueueHandle tun_queue_tx;
 
-static struct netif *tun_netif;
 static TaskHandle_t xtask = 0; // the task itself
 static u8_t volatile _task_should_stop = 0;
 
 void tunif_input(struct netif *netif);
 
 static void tun_task(void *args) {
+    struct netif *tun_netif = (struct netif *)args;
     while(0 == _task_should_stop) {
         tunif_input(tun_netif);
     }
@@ -237,7 +237,7 @@ err_t tunif_init(struct netif *netif) {
         usleep(100); //wait some time for tunif_input to exit
     }
     _task_should_stop = 0;
-    xTaskCreatePinnedToCore(tun_task, "tun", 1024, NULL, configMAX_PRIORITIES - 2, &xtask, xPortGetCoreID());
+    xTaskCreatePinnedToCore(tun_task, "tun", 1024, (void*)netif, configMAX_PRIORITIES - 2, &xtask, xPortGetCoreID());
 
     return ERR_OK;
 }

--- a/components/sys/lwip/netif/tunif.c
+++ b/components/sys/lwip/netif/tunif.c
@@ -106,13 +106,15 @@ extern xQueueHandle tun_queue_tx;
 
 static struct netif *tun_netif;
 static TaskHandle_t xtask = 0; // the task itself
+static u8_t volatile _task_should_stop = 0;
 
 void tunif_input(struct netif *netif);
 
 static void tun_task(void *args) {
-    for(;;) {
+    while(0 == _task_should_stop) {
         tunif_input(tun_netif);
     }
+    vTaskDelete(NULL);
 }
 
 /**
@@ -231,9 +233,10 @@ err_t tunif_init(struct netif *netif) {
     tun_netif = netif;
 
     if (xtask) {
-        vTaskDelete(xtask);
-        xtask = 0;
+        _task_should_stop = 1;
+        usleep(100); //wait some time for tunif_input to exit
     }
+    _task_should_stop = 0;
     xTaskCreatePinnedToCore(tun_task, "tun", 1024, NULL, configMAX_PRIORITIES - 2, &xtask, xPortGetCoreID());
 
     return ERR_OK;


### PR DESCRIPTION
must not delete the task while it's inside tunif_input
now openvpn looks pretty stable. but it's losing memory.