### PR TITLE
query file system usage

### DIFF
--- a/components/lfs/lfs.c
+++ b/components/lfs/lfs.c
@@ -2564,3 +2564,29 @@ int lfs_deorphan(lfs_t *lfs) {
 
     return 0;
 }
+
+static int lfs_statvfs_count(void *p, lfs_block_t b)
+{
+    *(lfs_size_t *)p += 1;
+    return 0;
+}
+
+int lfs_info(lfs_t *lfs, uint32_t *total, uint32_t *used)
+{
+    lfs_size_t in_use = 0;
+    int err = lfs_traverse(lfs, lfs_statvfs_count, &in_use);
+    if (err) {
+        LFS_ERROR("lfs_info got error %d", err);
+        return err;
+    }
+
+    if (total) {
+      *total = lfs->cfg->block_count * lfs->cfg->block_size;
+    }
+
+    if (used) {
+      *used = in_use * lfs->cfg->block_size;
+    }
+
+    return 0;
+}

--- a/components/lfs/lfs.h
+++ b/components/lfs/lfs.h
@@ -486,6 +486,7 @@ int lfs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 // Returns a negative error code on failure.
 int lfs_deorphan(lfs_t *lfs);
 
+int lfs_info(lfs_t *lfs, uint32_t *total, uint32_t *used);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lua/common/shell.c
+++ b/components/lua/common/shell.c
@@ -81,6 +81,7 @@ static const command_t command[] = {
     {"reboot", "os", "exit", 0, 0, NULL},
     {"ls", "os", "ls", 0, 1, "ls [pattern]"},
     {"dir", "os", "ls", 0, 1, "dir [pattern]"},
+    {"df", "os", "df", 0, 1, "df [target]"},
     {"luac", NULL, "compile", 1, 0, "luac source destination"},
     {"luad", NULL, "decompile", 1, 0, "luad source"},
     {"mkfs", "os", "format", 1, 0, "format path"},

--- a/components/lua/modules/sys/fs.c
+++ b/components/lua/modules/sys/fs.c
@@ -57,6 +57,9 @@
 
 #if CONFIG_LUA_RTOS_LUA_USE_FS
 
+int os_format(lua_State *L);
+int os_df(lua_State *L);
+
 static int l_mount(lua_State *L) {
     const char *target = luaL_checkstring(L, 1);
     if (!target) {
@@ -114,10 +117,20 @@ static int l_umount(lua_State *L) {
     return 0;
 }
 
+static int l_format(lua_State *L) {
+    return os_format(L);
+}
+
+static int l_usage(lua_State *L) {
+    return os_df(L);
+}
+
 static const LUA_REG_TYPE fs_map[] =
 {
   { LSTRKEY( "mount" ),      LFUNCVAL( l_mount  ) },
   { LSTRKEY( "umount" ),     LFUNCVAL( l_umount ) },
+  { LSTRKEY( "format" ),     LFUNCVAL( l_format ) },
+  { LSTRKEY( "usage" ),      LFUNCVAL( l_usage  ) },
   { LNILKEY, LNILVAL }
 };
 

--- a/components/lua/modules/sys/loslib_adds.inc
+++ b/components/lua/modules/sys/loslib_adds.inc
@@ -585,7 +585,7 @@ static int os_stats(lua_State *L) {
     return 0;
 }
 
-static int os_format(lua_State *L) {
+int os_format(lua_State *L) {
     const char *path = luaL_checkstring(L, 1);
 
     const struct mount_pt *mountp;
@@ -618,6 +618,25 @@ static int os_format(lua_State *L) {
 
     printf("%s can't be formatted\r\n", path);
 
+    return 0;
+}
+
+int os_df(lua_State *L) {
+    const char *path = luaL_optstring(L, 1, "/");
+    const struct mount_pt *mountp;
+
+    if ((mountp = mount_get_mount_point_for_path(path))) {
+        if (mountp->fsstat) {
+            uint32_t total, used;
+            if (0 == mountp->fsstat(path, &total, &used)) {
+                lua_pushinteger(L, total-used); // free
+                lua_pushinteger(L, total);      // total
+                return 2;
+            }
+        }
+    }
+
+    printf("can't get free space of %s\r\n", path);
     return 0;
 }
 

--- a/components/lua/src/loslib.c
+++ b/components/lua/src/loslib.c
@@ -534,6 +534,7 @@ static const LUA_REG_TYPE syslib[] =
   { LSTRKEY( "bootcount" ),   LFUNCVAL( os_bootcount ) },
   { LSTRKEY( "flashEUI" ),    LFUNCVAL( os_flash_unique_id ) },
   { LSTRKEY( "edit" ),        LFUNCVAL( os_edit ) },
+  { LSTRKEY( "df" ),          LFUNCVAL( os_df ) },
 
   { LSTRKEY( "LOG_INFO" ),    LINTVAL( LOG_INFO    ) },
   { LSTRKEY( "LOG_EMERG" ),   LINTVAL( LOG_EMERG   ) },

--- a/components/romfs/romfs.h
+++ b/components/romfs/romfs.h
@@ -86,7 +86,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include <machine/endian.h>
+#include <endian.h>
 
 #if (BYTE_ORDER == BIG_ENDIAN)
 #define htole16(x) __builtin_bswap16(x)

--- a/components/sys/sys/mount.c
+++ b/components/sys/sys/mount.c
@@ -69,22 +69,22 @@ void _mount_init() {
 // Current mount points
 struct mount_pt mountps[] = {
 #if (CONFIG_SD_CARD_MMC || CONFIG_SD_CARD_SPI) && CONFIG_LUA_RTOS_USE_FAT
-    {NULL, "fat", &vfs_fat_mount, &vfs_fat_umount, &vfs_fat_format, 0},
+    {NULL, "fat", &vfs_fat_mount, &vfs_fat_umount, &vfs_fat_format, &vfs_fat_fsstat, 0},
 #endif
 #if CONFIG_LUA_RTOS_USE_LFS
-    {NULL, "lfs", &vfs_lfs_mount, &vfs_lfs_umount, &vfs_lfs_format, 0},
+    {NULL, "lfs", &vfs_lfs_mount, &vfs_lfs_umount, &vfs_lfs_format, &vfs_lfs_fsstat, 0},
 #endif
 #if CONFIG_LUA_RTOS_USE_RAM_FS
-    {NULL, "ramfs", &vfs_ramfs_mount, &vfs_ramfs_umount, &vfs_ramfs_format, 0},
+    {NULL, "ramfs", &vfs_ramfs_mount, &vfs_ramfs_umount, &vfs_ramfs_format, &vfs_ramfs_fsstat, 0},
 #endif
 #if CONFIG_LUA_RTOS_USE_ROM_FS
-    {NULL, "romfs", &vfs_romfs_mount, &vfs_romfs_umount, NULL, 0},
+    {NULL, "romfs", &vfs_romfs_mount, &vfs_romfs_umount, NULL, &vfs_romfs_fsstat, 0},
 #endif
 #if CONFIG_LUA_RTOS_USE_SPIFFS
-   {NULL, "spiffs", &vfs_spiffs_mount, &vfs_spiffs_umount, &vfs_spiffs_format, 0},
+   {NULL, "spiffs", &vfs_spiffs_mount, &vfs_spiffs_umount, &vfs_spiffs_format, &vfs_spiffs_fsstat, 0},
 #endif
-    {"/dev", "dev", NULL, NULL, NULL, 0},
-    {NULL, NULL, NULL, NULL, NULL, 0}
+    {"/dev", "dev", NULL, NULL, NULL, NULL, 0},
+    {NULL, NULL, NULL, NULL, NULL, NULL, 0}
 };
 
 static char *dot_dot(char *rpath, char *cpath) {
@@ -572,7 +572,8 @@ struct mount_pt *mount_get_mount_point_for_path(const char *path) {
         ppath++;
         while (cmount->fs) {
             if (strcmp(ppath, cmount->fs) == 0) {
-                free(--ppath);
+                ppath--;
+                free(ppath);
                 mtx_unlock(&mtx);
                 return cmount;
             }
@@ -580,7 +581,8 @@ struct mount_pt *mount_get_mount_point_for_path(const char *path) {
             cmount++;
         }
 
-        free(--ppath);
+        ppath--;
+        free(ppath);
     }
 
 	mtx_unlock(&mtx);

--- a/components/sys/sys/mount.h
+++ b/components/sys/sys/mount.h
@@ -53,6 +53,7 @@
 typedef int (*mount_mount_f_t)(const char *);
 typedef int (*mount_umount_f_t)(const char *);
 typedef int (*mount_format_f_t)(const char *);
+typedef int (*mount_fsstat_f_t)(const char *, uint32_t *total, uint32_t *used);
 
 // Mount point structure
 struct mount_pt {
@@ -61,6 +62,7 @@ struct mount_pt {
     mount_mount_f_t mount;    // mount function
     mount_umount_f_t umount;  // unmount function
     mount_format_f_t format;  // format function
+    mount_fsstat_f_t fsstat;  // fs stat function
     uint8_t mounted;          // Is the file system mounted?
 };
 

--- a/components/sys/vfs/fat.c
+++ b/components/sys/vfs/fat.c
@@ -420,4 +420,34 @@ int vfs_fat_format(const char *target) {
 
     return 0;
 }
+
+int vfs_fat_fsstat(const char *target, u32_t *total, u32_t *used) {
+    DWORD nclst = 0;
+    FATFS* fs = NULL;
+    FRESULT err = f_getfree (target, &nclst, &fs);
+
+    if (err != FR_OK) {
+        syslog(LOG_ERR, "fat get fs info of '%s' (%i)", target, err);
+        return -1;
+    }
+
+    //fs->free_clst and nclst both are equal and give the number of free clusters
+    //fs->csize = Cluster size [sectors]
+    //fs->ssize = Sector size (512, 1024, 2048 or 4096)
+    //fs->fsize = Size of an FAT [sectors]
+    //fs->n_fatent = nclst + 2
+
+    DWORD	tclst = fs->n_fatent - 2;
+
+    if (total) {
+      *total = tclst * fs->csize * fs->ssize;
+    }
+
+    if (used) {
+      *used = (tclst - nclst) * fs->csize * fs->ssize;
+    }
+
+    return 0;
+}
+
 #endif

--- a/components/sys/vfs/lfs.c
+++ b/components/sys/vfs/lfs.c
@@ -935,4 +935,15 @@ int vfs_lfs_format(const char *target) {
     return -1;
 }
 
+int vfs_lfs_fsstat(const char *target, u32_t *total, u32_t *used) {
+
+    int err = lfs_info(&lfs, total, used);
+    if (err != 0) {
+        syslog(LOG_ERR, "lfs get fs info of '%s' (%i)", target, err);
+        return -1;
+    }
+
+    return 0;
+}
+
 #endif

--- a/components/sys/vfs/ramfs.c
+++ b/components/sys/vfs/ramfs.c
@@ -618,4 +618,17 @@ int vfs_ramfs_format(const char *target) {
     return 0;
 }
 
+int vfs_ramfs_fsstat(const char *target, u32_t *total, u32_t *used) {
+
+    if (total) {
+      *total = fs.size;
+    }
+
+    if (used) {
+      *used = fs.current_size;
+    }
+
+    return 0;
+}
+
 #endif

--- a/components/sys/vfs/romfs.c
+++ b/components/sys/vfs/romfs.c
@@ -569,4 +569,17 @@ int vfs_romfs_umount(const char *target) {
     return 0;
 }
 
+int vfs_romfs_fsstat(const char *target, u32_t *total, u32_t *used) {
+
+    if (total) {
+      *total = 0;
+    }
+
+    if (used) {
+      *used = 0;
+    }
+
+    return 0;
+}
+
 #endif

--- a/components/sys/vfs/spiffs.c
+++ b/components/sys/vfs/spiffs.c
@@ -1328,4 +1328,15 @@ int vfs_spiffs_format(const char *target) {
     return 0;
 }
 
+int vfs_spiffs_fsstat(const char *target, u32_t *total, u32_t *used) {
+
+    if (SPIFFS_info(&fs, total, used) != SPIFFS_OK) {
+        syslog(LOG_ERR, "spiffs get fs info of '%s' (%s)", target,
+                strerror(spiffs_result(fs.err_code)));
+        return -1;
+    }
+
+    return 0;
+}
+
 #endif

--- a/components/sys/vfs/vfs.h
+++ b/components/sys/vfs/vfs.h
@@ -92,21 +92,26 @@ typedef void(*vfs_put_byte)(int,char *);
 int vfs_fat_mount(const char *target);
 int vfs_fat_umount(const char *target);
 int vfs_fat_format(const char *target);
+int vfs_fat_fsstat(const char *target, u32_t *total, u32_t *used);
 
 int vfs_spiffs_mount(const char *target);
 int vfs_spiffs_umount(const char *target);
 int vfs_spiffs_format(const char *target);
+int vfs_spiffs_fsstat(const char *target, u32_t *total, u32_t *used);
 
 int vfs_lfs_mount(const char *target);
 int vfs_lfs_umount(const char *target);
 int vfs_lfs_format(const char *target);
+int vfs_lfs_fsstat(const char *target, u32_t *total, u32_t *used);
 
 int vfs_ramfs_mount(const char *target);
 int vfs_ramfs_umount(const char *target);
 int vfs_ramfs_format(const char *target);
+int vfs_ramfs_fsstat(const char *target, u32_t *total, u32_t *used);
 
 int vfs_romfs_mount(const char *target);
 int vfs_romfs_umount(const char *target);
+int vfs_romfs_fsstat(const char *target, u32_t *total, u32_t *used);
 
 int vfs_generic_fcntl(vfs_fd_local_storage_t *local_storage, int fd, int cmd, va_list args);
 ssize_t vfs_generic_read(vfs_fd_local_storage_t *local_storage, vfs_has_bytes has_bytes, vfs_get_byte get, int fd, void * dst, size_t size);


### PR DESCRIPTION
added support to query the current fs usage:
```
/ > os.df()
/ > df
/ > fs.usage()
/ > os.df("/")
/ > os.df("/rfs")
/ > os.df("/sd")
```
First value returned is free space, second value is total space, e.g. for a spiffs root, 128mb fat-formatted sd-card with 12mb used, 4k ramfs:
```
/examples/lua > os.df("/")
358679        482673
/examples/lua > os.df("/sd")
238791168        251984384
/examples/lua > os.df("/rfs")
4096        4096
/examples/lua >
```
also linked os.format to the fs module, which might look more logical:
```
/ > fs.format()
/ > fs.format("/sd")
```