### PR TITLE
fixed backtrace table row index

### DIFF
--- a/components/lua/modules/hw/cpu.c
+++ b/components/lua/modules/hw/cpu.c
@@ -297,7 +297,7 @@ static int lcpu_backtrace(lua_State *L) {
     for (uint32_t idx = 0; idx < MAX_BACKTRACE && idx < backtrace_count; idx++) {
         if (bPrint) printf(" 0x%08x:0x%08x", backtrace_pc[idx], backtrace_sp[idx]);
 
-        lua_pushnumber(L, idx); //row index
+        lua_pushnumber(L, idx+1); //row index starts from 1
         lua_newtable(L);
 
         lua_pushinteger(L, backtrace_pc[idx]);


### PR DESCRIPTION
previously the most important backtrace line had index 0
which had put it into the *last* table row instead of the first