### PR TITLE
avoid using bad memory in mqtt

### DIFF
--- a/components/mqtt/LinkedList.c
+++ b/components/mqtt/LinkedList.c
@@ -56,6 +56,9 @@ void ListZero(List* newl)
 List* ListInitialize(void)
 {
 	List* newl = malloc(sizeof(List));
+#if __XTENSA__
+  if (newl)
+#endif
 	ListZero(newl);
 	return newl;
 }
@@ -71,6 +74,9 @@ List* ListInitialize(void)
  */
 void ListAppendNoMalloc(List* aList, void* content, ListElement* newel, size_t size)
 { /* for heap use */
+#if __XTENSA__
+  if (aList) {
+#endif
 	newel->content = content;
 	newel->next = NULL;
 	newel->prev = aList->last;
@@ -81,6 +87,9 @@ void ListAppendNoMalloc(List* aList, void* content, ListElement* newel, size_t s
 	aList->last = newel;
 	++(aList->count);
 	aList->size += size;
+#if __XTENSA__
+  }
+#endif
 }
 
 
@@ -92,8 +101,17 @@ void ListAppendNoMalloc(List* aList, void* content, ListElement* newel, size_t s
  */
 void ListAppend(List* aList, void* content, size_t size)
 {
+#if __XTENSA__
+  if (aList) {
+#endif
 	ListElement* newel = malloc(sizeof(ListElement));
+#if __XTENSA__
+  if (newel)
+#endif
 	ListAppendNoMalloc(aList, content, newel, size);
+#if __XTENSA__
+  }
+#endif
 }
 
 
@@ -107,7 +125,13 @@ void ListAppend(List* aList, void* content, size_t size)
  */
 void ListInsert(List* aList, void* content, size_t size, ListElement* index)
 {
+#if __XTENSA__
+  if (aList) {
+#endif
 	ListElement* newel = malloc(sizeof(ListElement));
+#if __XTENSA__
+  if (newel) {
+#endif
 
 	if ( index == NULL )
 		ListAppendNoMalloc(aList, content, newel, size);
@@ -126,6 +150,10 @@ void ListInsert(List* aList, void* content, size_t size, ListElement* index)
 		++(aList->count);
 		aList->size += size;
 	}
+#if __XTENSA__
+  }
+  }
+#endif
 }
 
 
@@ -153,6 +181,9 @@ ListElement* ListFindItem(List* aList, void* content, int(*callback)(void*, void
 {
 	ListElement* rc = NULL;
 
+#if __XTENSA__
+  if (aList) {
+#endif
 	if (aList->current != NULL && ((callback == NULL && aList->current->content == content) ||
 		   (callback != NULL && callback(aList->current->content, content))))
 		rc = aList->current;
@@ -183,6 +214,9 @@ ListElement* ListFindItem(List* aList, void* content, int(*callback)(void*, void
 		if (rc != NULL)
 			aList->current = rc;
 	}
+#if __XTENSA__
+  }
+#endif
 	return rc;
 }
 
@@ -198,6 +232,9 @@ ListElement* ListFindItem(List* aList, void* content, int(*callback)(void*, void
  */
 static int ListUnlink(List* aList, void* content, int(*callback)(void*, void*), int freeContent)
 {
+#if __XTENSA__
+  if (aList) {
+#endif
 	ListElement* next = NULL;
 	ListElement* saved = aList->current;
 	int saveddeleted = 0;
@@ -230,6 +267,9 @@ static int ListUnlink(List* aList, void* content, int(*callback)(void*, void*), 
 	else
 		aList->current = saved;
 	--(aList->count);
+#if __XTENSA__
+  }
+#endif
 	return 1; /* successfully removed item */
 }
 
@@ -266,6 +306,9 @@ int ListRemove(List* aList, void* content)
 void* ListDetachHead(List* aList)
 {
 	void *content = NULL;
+#if __XTENSA__
+  if (aList) {
+#endif
 	if (aList->count > 0)
 	{
 		ListElement* first = aList->first;
@@ -280,6 +323,9 @@ void* ListDetachHead(List* aList)
 		free(first);
 		--(aList->count);
 	}
+#if __XTENSA__
+  }
+#endif
 	return content;
 }
 
@@ -304,6 +350,9 @@ int ListRemoveHead(List* aList)
 void* ListPopTail(List* aList)
 {
 	void* content = NULL;
+#if __XTENSA__
+  if (aList) {
+#endif
 	if (aList->count > 0)
 	{
 		ListElement* last = aList->last;
@@ -318,6 +367,9 @@ void* ListPopTail(List* aList)
 		free(last);
 		--(aList->count);
 	}
+#if __XTENSA__
+  }
+#endif
 	return content;
 }
 
@@ -356,6 +408,9 @@ int ListRemoveItem(List* aList, void* content, int(*callback)(void*, void*))
  */
 void ListEmpty(List* aList)
 {
+#if __XTENSA__
+  if (aList) {
+#endif
 	while (aList->first != NULL)
 	{
 		ListElement* first = aList->first;
@@ -370,6 +425,9 @@ void ListEmpty(List* aList)
 	aList->count = 0;
 	aList->size = 0;
 	aList->current = aList->first = aList->last = NULL;
+#if __XTENSA__
+  }
+#endif
 }
 
 /**
@@ -389,6 +447,9 @@ void ListFree(List* aList)
  */
 void ListFreeNoContent(List* aList)
 {
+#if __XTENSA__
+  if (aList) {
+#endif
 	while (aList->first != NULL)
 	{
 		ListElement* first = aList->first;
@@ -396,6 +457,9 @@ void ListFreeNoContent(List* aList)
 		free(first);
 	}
 	free(aList);
+#if __XTENSA__
+  }
+#endif
 }
 
 

--- a/components/mqtt/MQTTAsync.h
+++ b/components/mqtt/MQTTAsync.h
@@ -1185,7 +1185,9 @@ typedef struct
   * MQTTASYNC_TRACE_MINIMUM
   * @return an array of strings describing the library.  The last entry is a NULL pointer.
   */
+#if !__XTENSA__
 DLLExport MQTTAsync_nameValue* MQTTAsync_getVersionInfo(void);
+#endif
 
 /**
  * Returns a pointer to the string representation of the error or NULL.

--- a/components/mqtt/MQTTPacket.c
+++ b/components/mqtt/MQTTPacket.c
@@ -51,8 +51,9 @@ static const char *packet_names[] =
 	"PINGREQ", "PINGRESP", "DISCONNECT"
 };
 
+#if !__XTENSA__
 const char** MQTTClient_packet_names = packet_names;
-
+#endif
 
 /**
  * Converts an MQTT packet code into its name
@@ -67,6 +68,9 @@ const char* MQTTPacket_name(int ptype)
 /**
  * Array of functions to build packets, indexed according to packet code
  */
+#if __XTENSA__
+const
+#endif
 pf new_packets[] =
 {
 	NULL,	/**< reserved */
@@ -150,11 +154,17 @@ void* MQTTPacket_Factory(networkHandles* net, int* error)
 			{
 				int buf0len;
 				char *buf = malloc(10);
+#if __XTENSA__
+        if (buf) {
+#endif
 				buf[0] = header.byte;
 				buf0len = 1 + MQTTPacket_encode(&buf[1], remaining_length);
 				*error = MQTTPersistence_put(net->socket, buf, buf0len, 1,
 					&data, &remaining_length, header.bits.type, ((Publish *)pack)->msgId, 1);
 				free(buf);
+#if __XTENSA__
+        }
+#endif
 			}
 #endif
 		}
@@ -184,6 +194,10 @@ int MQTTPacket_send(networkHandles* net, Header header, char* buffer, size_t buf
 
 	FUNC_ENTRY;
 	buf = malloc(10);
+#if __XTENSA__
+  rc = 0;
+  if (buf) {
+#endif
 	buf[0] = header.byte;
 	buf0len = 1 + MQTTPacket_encode(&buf[1], buflen);
 
@@ -212,6 +226,9 @@ int MQTTPacket_send(networkHandles* net, Header header, char* buffer, size_t buf
 	
 	if (rc != TCPSOCKET_INTERRUPTED)
 	  free(buf);
+#if __XTENSA__
+  }
+#endif
 
 	FUNC_EXIT_RC(rc);
 	return rc;
@@ -235,6 +252,10 @@ int MQTTPacket_sends(networkHandles* net, Header header, int count, char** buffe
 
 	FUNC_ENTRY;
 	buf = malloc(10);
+#if __XTENSA__
+  rc = 0;
+  if (buf) {
+#endif
 	buf[0] = header.byte;
 	for (i = 0; i < count; i++)
 		total += buflens[i];
@@ -260,6 +281,10 @@ int MQTTPacket_sends(networkHandles* net, Header header, int count, char** buffe
 	
 	if (rc != TCPSOCKET_INTERRUPTED)
 	  free(buf);
+
+#if __XTENSA__
+  }
+#endif
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -366,8 +391,14 @@ static char* readUTFlen(char** pptr, char* enddata, int* len)
 		if (&(*pptr)[*len] <= enddata)
 		{
 			string = malloc(*len+1);
+#if __XTENSA__
+      if (string) {
+#endif
 			memcpy(string, *pptr, *len);
 			string[*len] = '\0';
+#if __XTENSA__
+      }
+#endif
 			*pptr += *len;
 		}
 	}
@@ -505,6 +536,9 @@ int MQTTPacket_send_disconnect(networkHandles *net, const char* clientID)
 void* MQTTPacket_publish(unsigned char aHeader, char* data, size_t datalen)
 {
 	Publish* pack = malloc(sizeof(Publish));
+#if __XTENSA__
+  if (pack) {
+#endif
 	char* curdata = data;
 	char* enddata = &data[datalen];
 
@@ -522,6 +556,10 @@ void* MQTTPacket_publish(unsigned char aHeader, char* data, size_t datalen)
 		pack->msgId = 0;
 	pack->payload = curdata;
 	pack->payloadlen = (int)(datalen-(curdata-data));
+
+#if __XTENSA__
+  }
+#endif
 exit:
 	FUNC_EXIT;
 	return pack;
@@ -558,6 +596,10 @@ static int MQTTPacket_send_ack(int type, int msgid, int dup, networkHandles *net
 	char *ptr = buf;
 
 	FUNC_ENTRY;
+#if __XTENSA__
+  rc = 0;
+  if (buf) {
+#endif
 	header.byte = 0;
 	header.bits.type = type;
 	header.bits.dup = dup;
@@ -566,6 +608,9 @@ static int MQTTPacket_send_ack(int type, int msgid, int dup, networkHandles *net
 	writeInt(&ptr, msgid);
 	if ((rc = MQTTPacket_send(net, header, buf, 2, 1)) != TCPSOCKET_INTERRUPTED)
 		free(buf);
+#if __XTENSA__
+  }
+#endif
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -675,8 +720,14 @@ void* MQTTPacket_ack(unsigned char aHeader, char* data, size_t datalen)
 	char* curdata = data;
 
 	FUNC_ENTRY;
+#if __XTENSA__
+  if (pack) {
+#endif
 	pack->header.byte = aHeader;
 	pack->msgId = readInt(&curdata);
+#if __XTENSA__
+  }
+#endif
 	FUNC_EXIT;
 	return pack;
 }
@@ -700,6 +751,9 @@ int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, netwo
 
 	FUNC_ENTRY;
 	topiclen = malloc(2);
+#if __XTENSA__
+  if (pack && net && topiclen) {
+#endif
 
 	header.bits.type = PUBLISH;
 	header.bits.dup = dup;
@@ -708,6 +762,9 @@ int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, netwo
 	if (qos > 0)
 	{
 		char *buf = malloc(2);
+#if __XTENSA__
+    if (buf) {
+#endif
 		char *ptr = buf;
 		char* bufs[4] = {topiclen, pack->topic, buf, pack->payload};
 		size_t lens[4] = {2, strlen(pack->topic), 2, pack->payloadlen};
@@ -719,6 +776,9 @@ int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, netwo
 		rc = MQTTPacket_sends(net, header, 4, bufs, lens, frees);
 		if (rc != TCPSOCKET_INTERRUPTED)
 			free(buf);
+#if __XTENSA__
+    }
+#endif
 	}
 	else
 	{
@@ -737,6 +797,11 @@ int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, netwo
 	else
 		Log(LOG_PROTOCOL, 10, NULL, net->socket, clientID, pack->msgId, qos, retained, rc,
 				min(20, pack->payloadlen), pack->payload);
+
+#if __XTENSA__
+  }
+  else free(topiclen);
+#endif
 	FUNC_EXIT_RC(rc);
 	return rc;
 }

--- a/components/mqtt/MQTTPacketOut.c
+++ b/components/mqtt/MQTTPacketOut.c
@@ -61,6 +61,9 @@ int MQTTPacket_send_connect(Clients* client, int MQTTVersion)
 		len += client->passwordlen+2;
 
 	ptr = buf = malloc(len);
+#if __XTENSA__
+  if (!ptr) goto exit;
+#endif
 	if (MQTTVersion == 3)
 	{
 		writeUTF(&ptr, "MQIsdp");
@@ -124,9 +127,15 @@ void* MQTTPacket_connack(unsigned char aHeader, char* data, size_t datalen)
 	char* curdata = data;
 
 	FUNC_ENTRY;
+#if __XTENSA__
+  if (pack) {
+#endif
 	pack->header.byte = aHeader;
 	pack->flags.all = readChar(&curdata);
 	pack->rc = readChar(&curdata);
+#if __XTENSA__
+  }
+#endif
 	FUNC_EXIT;
 	return pack;
 }
@@ -182,6 +191,9 @@ int MQTTPacket_send_subscribe(List* topics, List* qoss, int msgid, int dup, netw
 		datalen += (int)strlen((char*)(elem->content));
 	ptr = data = malloc(datalen);
 
+#if __XTENSA__
+  if (ptr) {
+#endif
 	writeInt(&ptr, msgid);
 	elem = NULL;
 	while (ListNextElement(topics, &elem))
@@ -194,6 +206,9 @@ int MQTTPacket_send_subscribe(List* topics, List* qoss, int msgid, int dup, netw
 	Log(LOG_PROTOCOL, 22, NULL, net->socket, clientID, msgid, rc);
 	if (rc != TCPSOCKET_INTERRUPTED)
 		free(data);
+#if __XTENSA__
+  }
+#endif
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -212,6 +227,9 @@ void* MQTTPacket_suback(unsigned char aHeader, char* data, size_t datalen)
 	char* curdata = data;
 
 	FUNC_ENTRY;
+#if __XTENSA__
+  if (pack) {
+#endif
 	pack->header.byte = aHeader;
 	pack->msgId = readInt(&curdata);
 	pack->qoss = ListInitialize();
@@ -219,9 +237,18 @@ void* MQTTPacket_suback(unsigned char aHeader, char* data, size_t datalen)
 	{
 		int* newint;
 		newint = malloc(sizeof(int));
+#if __XTENSA__
+    if (newint) {
+#endif
 		*newint = (int)readChar(&curdata);
 		ListAppend(pack->qoss, newint, sizeof(int));
+#if __XTENSA__
+    }
+#endif
 	}
+#if __XTENSA__
+  }
+#endif
 	FUNC_EXIT;
 	return pack;
 }
@@ -255,6 +282,9 @@ int MQTTPacket_send_unsubscribe(List* topics, int msgid, int dup, networkHandles
 		datalen += (int)strlen((char*)(elem->content));
 	ptr = data = malloc(datalen);
 
+#if __XTENSA__
+  if (ptr) {
+#endif
 	writeInt(&ptr, msgid);
 	elem = NULL;
 	while (ListNextElement(topics, &elem))
@@ -263,6 +293,9 @@ int MQTTPacket_send_unsubscribe(List* topics, int msgid, int dup, networkHandles
 	Log(LOG_PROTOCOL, 25, NULL, net->socket, clientID, msgid, rc);
 	if (rc != TCPSOCKET_INTERRUPTED)
 		free(data);
+#if __XTENSA__
+  }
+#endif
 	FUNC_EXIT_RC(rc);
 	return rc;
 }

--- a/components/mqtt/Socket.c
+++ b/components/mqtt/Socket.c
@@ -186,6 +186,9 @@ int Socket_addSocket(int newSd)
 		else
 		{
 			int* pnewSd = (int*)malloc(sizeof(newSd));
+#if __XTENSA__
+      if (pnewSd) {
+#endif
 			*pnewSd = newSd;
 			ListAppend(s.clientsds, pnewSd, sizeof(newSd));
 			FD_SET(newSd, &(s.rset_saved));
@@ -193,6 +196,9 @@ int Socket_addSocket(int newSd)
 			rc = Socket_setnonblocking(newSd);
 			if (rc == SOCKET_ERROR)
 				Log(LOG_ERROR, -1, "addSocket: setnonblocking");
+#if __XTENSA__
+      }
+#endif
 		}
 	}
 	else
@@ -539,8 +545,14 @@ int Socket_putdatas(int socket, char* buf0, size_t buf0len, int count, char** bu
 #else
 			SocketBuffer_pendingWrite(socket, count+1, iovecs, frees1, total, bytes);
 #endif
+#if __XTENSA__
+      if (sockmem) {
+#endif
 			*sockmem = socket;
 			ListAppend(s.write_pending, sockmem, sizeof(int));
+#if __XTENSA__
+      }
+#endif
 			FD_SET(socket, &(s.pending_wset));
 			rc = TCPSOCKET_INTERRUPTED;
 		}
@@ -952,6 +964,7 @@ int Socket_continueWrites(fd_set* pwset)
  *  @param sock socket
  *  @return the peer information
  */
+#if !__XTENSA__
 char* Socket_getaddrname(struct sockaddr* sa, int sock)
 {
 /**
@@ -1006,7 +1019,7 @@ char* Socket_getpeer(int sock)
 
 	return Socket_getaddrname((struct sockaddr*)&sa, sock);
 }
-
+#endif
 
 #if defined(Socket_TEST)
 

--- a/components/mqtt/Socket.h
+++ b/components/mqtt/Socket.h
@@ -146,7 +146,9 @@ void Socket_close(int socket);
 int Socket_new(char* addr, int port, int* socket);
 
 int Socket_noPendingWrites(int socket);
+#if !__XTENSA__
 char* Socket_getpeer(int sock);
+#endif
 
 void Socket_addPendingWrite(int socket);
 void Socket_clearPendingWrite(int socket);

--- a/components/mqtt/SocketBuffer.c
+++ b/components/mqtt/SocketBuffer.c
@@ -79,10 +79,21 @@ int socketcompare(void* a, void* b)
 void SocketBuffer_newDefQ(void)
 {
 	def_queue = malloc(sizeof(socket_queue));
+#if __XTENSA__
+  if (def_queue) {
+#endif
 	def_queue->buflen = 1000;
 	def_queue->buf = malloc(def_queue->buflen);
+#if __XTENSA__
+  if (!def_queue->buf) {
+    fprintf(stderr, "Error allocating def_queue->buf - continuing");
+  }
+#endif
 	def_queue->socket = def_queue->index = 0;
 	def_queue->buflen = def_queue->datalen = 0;
+#if __XTENSA__
+  }
+#endif
 }
 
 
@@ -176,6 +187,9 @@ char* SocketBuffer_getQueuedData(int socket, size_t bytes, size_t* actual_len)
 		if (queue->datalen > 0)
 		{
 			void* newmem = malloc(bytes);
+#if __XTENSA__
+      if (newmem)
+#endif
 			memcpy(newmem, queue->buf, queue->datalen);
 			free(queue->buf);
 			queue->buf = newmem;
@@ -335,6 +349,9 @@ void SocketBuffer_pendingWrite(int socket, int count, iobuf* iovecs, int* frees,
 	FUNC_ENTRY;
 	/* store the buffers until the whole packet is written */
 	pw = malloc(sizeof(pending_writes));
+#if __XTENSA__
+  if (pw) {
+#endif
 	pw->socket = socket;
 #if defined(OPENSSL)
 	pw->ssl = ssl;
@@ -348,6 +365,9 @@ void SocketBuffer_pendingWrite(int socket, int count, iobuf* iovecs, int* frees,
 		pw->frees[i] = frees[i];
 	}
 	ListAppend(&writes, pw, sizeof(pw) + total);
+#if __XTENSA__
+  }
+#endif
 	FUNC_EXIT;
 }
 

--- a/components/mqtt/Thread.c
+++ b/components/mqtt/Thread.c
@@ -112,6 +112,9 @@ mutex_type Thread_create_mutex(void)
 		#if !__XTENSA__
 		*mutex = PTHREAD_MUTEX_INITIALIZER;
 		#endif
+#if __XTENSA__
+    if (mutex)
+#endif
 		rc = pthread_mutex_init(mutex, NULL);
 	#endif
 	FUNC_EXIT_RC(rc);
@@ -221,6 +224,9 @@ sem_type Thread_create_sem(void)
 		rc = sem?0:-1;
 	#else
 		sem = malloc(sizeof(sem_t));
+#if __XTENSA__
+    if (sem)
+#endif
 		rc = sem_init(sem, 0, 0);
 	#endif
 	FUNC_EXIT_RC(rc);
@@ -367,8 +373,14 @@ cond_type Thread_create_cond(void)
 
 	FUNC_ENTRY;
 	condvar = malloc(sizeof(cond_type_struct));
+#if __XTENSA__
+  if (condvar) {
+#endif
 	rc = pthread_cond_init(&condvar->cond, NULL);
 	rc = pthread_mutex_init(&condvar->mutex, NULL);
+#if __XTENSA__
+  }
+#endif
 
 	FUNC_EXIT_RC(rc);
 	return condvar;


### PR DESCRIPTION
to avoid crashes, every memory allocation needs to be checked.
reduce static memory by avoiding functions that are never used anyway.