### PR TITLE
add missing NULL at end of some rotable to fix pairs() iterating

### DIFF
--- a/components/lua/common/lrodefs.h
+++ b/components/lua/common/lrodefs.h
@@ -18,7 +18,13 @@
 #define LNILVAL                     LRO_NILVAL
 #define LREGISTER(L, name, table)\
   return 0
+
+#define LNEWLIB(L, name)\
+  return 0
+
 #else
+#include "lauxlib.h"
+
 #define LUA_REG_TYPE                luaL_Reg
 #define LSTRKEY(x)                  x
 #define LNILKEY                     NULL
@@ -31,6 +37,12 @@
 #define LREGISTER(L, name, table)\
   luaL_register(L, name, table);\
   return 1
+
+#define LNEWLIB(L, name)\
+  luaL_newlib(L, name);\
+  return 1
+
+
 #endif
 	  
 #endif /* lrodefs_h */

--- a/components/lua/modules/bluetooth/bluetooth.c
+++ b/components/lua/modules/bluetooth/bluetooth.c
@@ -242,6 +242,7 @@ static int lbt_scan_stop( lua_State* L ) {
 
 static const LUA_REG_TYPE lbt_service[] = {
 	{ LSTRKEY( "eddystone" ), LROVAL ( eddystone_map ) },
+	{ LNILKEY, LNILVAL } 
 };
 
 static const LUA_REG_TYPE lbt_mode[] = {
@@ -249,6 +250,7 @@ static const LUA_REG_TYPE lbt_mode[] = {
 	{ LSTRKEY( "BLE"        ), LINTVAL( ((bt_mode_t)BLE)     ) },
 	{ LSTRKEY( "Classic"    ), LINTVAL( ((bt_mode_t)Classic) ) },
 	{ LSTRKEY( "Dual"       ), LINTVAL( ((bt_mode_t)Dual)    ) },
+	{ LNILKEY, LNILVAL } 
 };
 
 static const LUA_REG_TYPE lbt_adv_type[] = {
@@ -257,6 +259,7 @@ static const LUA_REG_TYPE lbt_adv_type[] = {
 	{ LSTRKEY( "ADV_DIRECT_IND_LOW"   ), LINTVAL( ADV_DIRECT_IND_LOW  ) },
 	{ LSTRKEY( "ADV_NONCONN_IND" 	 ), LINTVAL( ADV_NONCONN_IND 	 ) },
 	{ LSTRKEY( "ADV_SCAN_IND"    	 ), LINTVAL( ADV_SCAN_IND	     ) },
+	{ LNILKEY, LNILVAL } 
 };
 
 static const LUA_REG_TYPE lbt_own_addr_type[] = {
@@ -264,11 +267,13 @@ static const LUA_REG_TYPE lbt_own_addr_type[] = {
 	{ LSTRKEY( "Random"  		 ), LINTVAL( OwnRandom        ) },
 	{ LSTRKEY( "PrivatePublic"   ), LINTVAL( OwnPrivatePublic ) },
 	{ LSTRKEY( "PrivateRandom"   ), LINTVAL( OwnPrivateRandom ) },
+	{ LNILKEY, LNILVAL } 
 };
 
 static const LUA_REG_TYPE lbt_peer_addr_type[] = {
 	{ LSTRKEY( "Public"          ), LINTVAL( PeerPublic       ) },
 	{ LSTRKEY( "Random"  		 ), LINTVAL( PeerRandom       ) },
+	{ LNILKEY, LNILVAL } 
 };
 
 static const LUA_REG_TYPE lbt_adv_channel_map[] = {
@@ -276,6 +281,7 @@ static const LUA_REG_TYPE lbt_adv_channel_map[] = {
 	{ LSTRKEY( "38"              ), LINTVAL( Chann38       ) },
 	{ LSTRKEY( "39"              ), LINTVAL( Chann39       ) },
 	{ LSTRKEY( "All"             ), LINTVAL( AllChann      ) },
+	{ LNILKEY, LNILVAL } 
 };
 
 static const LUA_REG_TYPE lbt_adv_filter_policy[] = {
@@ -283,6 +289,7 @@ static const LUA_REG_TYPE lbt_adv_filter_policy[] = {
 	{ LSTRKEY( "ConnAllScanWhite"   ), LINTVAL( ConnAllScanWhite   ) },
 	{ LSTRKEY( "ConnWhiteScanAll"   ), LINTVAL( ConnWhiteScanAll   ) },
 	{ LSTRKEY( "ConnWhiteScanWhite" ), LINTVAL( ConnWhiteScanWhite ) },
+	{ LNILKEY, LNILVAL } 
 };
 
 static const LUA_REG_TYPE lbt_advertise_map[] = {

--- a/components/lua/modules/hw/cpu.c
+++ b/components/lua/modules/hw/cpu.c
@@ -365,12 +365,7 @@ static const LUA_REG_TYPE lcpu_map[] = {
 };
 
 LUALIB_API int luaopen_cpu( lua_State *L ) {
-#if !LUA_USE_ROTABLE
-    luaL_newlib(L, cpu);
-    return 1;
-#else
-    return 0;
-#endif
+    LNEWLIB(L, cpu);
 }
 
 MODULE_REGISTER_ROM(CPU, cpu, lcpu_map, luaopen_cpu, 1);

--- a/components/lua/modules/hw/gdisplay.c
+++ b/components/lua/modules/hw/gdisplay.c
@@ -1383,7 +1383,7 @@ static const LUA_REG_TYPE gdisplay_map[] = {
 	{ LSTRKEY( "setfixed" ),       LFUNCVAL( lgdisplay_setfixed )},
 	{ LSTRKEY( "setwrap" ),        LFUNCVAL( lgdisplay_setwrap )},
 	{ LSTRKEY( "setangleoffset" ), LFUNCVAL( lgdisplay_set_angleOffset )},
-	{ LSTRKEY( "setangleoffset" ), LFUNCVAL( lgdisplay_get_angleOffset )},
+	{ LSTRKEY( "getangleoffset" ), LFUNCVAL( lgdisplay_get_angleOffset )},
 	{ LSTRKEY( "setclipwin" ),     LFUNCVAL( lgdisplay_setclipwin )},
 	{ LSTRKEY( "resetclipwin" ),   LFUNCVAL( lgdisplay_resetclipwin )},
 	{ LSTRKEY( "getclipwin" ),     LFUNCVAL( lgdisplay_getclipwin )},

--- a/components/lua/modules/hw/rcswitch.c
+++ b/components/lua/modules/hw/rcswitch.c
@@ -86,12 +86,7 @@ static const LUA_REG_TYPE lrcswitch_map[] = {
 };
 
 LUALIB_API int luaopen_rcswitch( lua_State *L ) {
-#if !LUA_USE_ROTABLE
-  luaL_newlib(L, rcswitch);
-  return 1;
-#else
-	return 0;
-#endif
+  LNEWLIB(L, rcswitch);
 }
 
 MODULE_REGISTER_ROM(RCSWITCH, rcswitch, lrcswitch_map, luaopen_rcswitch, 1);

--- a/components/lua/modules/hw/touch.c
+++ b/components/lua/modules/hw/touch.c
@@ -187,12 +187,7 @@ static const LUA_REG_TYPE ltouch_map[] = {
 };
 
 LUALIB_API int luaopen_touch( lua_State *L ) {
-#if !LUA_USE_ROTABLE
-  luaL_newlib(L, touch);
-  return 1;
-#else
-	return 0;
-#endif
+  LNEWLIB(L, touch);
 }
 
 MODULE_REGISTER_ROM(TOUCH, touch, ltouch_map, luaopen_touch, 1);

--- a/components/lua/modules/hw/ulp.c
+++ b/components/lua/modules/hw/ulp.c
@@ -281,13 +281,8 @@ static const LUA_REG_TYPE lulp_service_map[] = {
 
 LUALIB_API int luaopen_ulp( lua_State *L ) {
   luaL_newmetarotable(L,"ulp.var", (void *)lulp_service_map);
-
-#if !LUA_USE_ROTABLE
-  luaL_newlib(L, ulp);
-  return 1;
-#else
-	return 0;
-#endif
+ 
+  LNEWLIB(L, ulp); 
 }
 
 MODULE_REGISTER_ROM(ULP, ulp, lulp_map, luaopen_ulp, 1);

--- a/components/lua/modules/middleware/mqtt.c
+++ b/components/lua/modules/middleware/mqtt.c
@@ -892,12 +892,7 @@ static const LUA_REG_TYPE lmqtt_client_map[] = {
 LUALIB_API int luaopen_mqtt( lua_State *L ) {
     luaL_newmetarotable(L,"mqtt.cli", (void *)lmqtt_client_map);
 
-#if !LUA_USE_ROTABLE
-    luaL_newlib(L, mqtt);
-    return 1;
-#else
-    return 0;
-#endif
+    LNEWLIB(L, mqtt);
 }
 
 MODULE_REGISTER_ROM(MQTT, mqtt, lmqtt_map, luaopen_mqtt, 1);

--- a/components/lua/modules/net/net_service_mdns.inc
+++ b/components/lua/modules/net/net_service_mdns.inc
@@ -474,12 +474,7 @@ static const LUA_REG_TYPE mdns_map[] = {
 
 //called from luaopen_net
 LUALIB_API int luaopen_mdns( lua_State *L ) {
-#if !LUA_USE_ROTABLE
-	luaL_newlib(L, mdns);
-	return 1;
-#else
-	return 0;
-#endif
+ 	LNEWLIB(L, mdns);
 }
 
 #endif

--- a/components/lua/modules/net/net_wifi.inc
+++ b/components/lua/modules/net/net_wifi.inc
@@ -525,6 +525,7 @@ static const LUA_REG_TYPE wifi_auth_map[] = {
     { LSTRKEY( "WPA_PSK"      ), LINTVAL( WIFI_AUTH_WPA_PSK ) },
     { LSTRKEY( "WPA2_PSK"     ), LINTVAL( WIFI_AUTH_WPA2_PSK ) },
     { LSTRKEY( "WPA_WPA2_PSK" ), LINTVAL( WIFI_AUTH_WPA_WPA2_PSK ) },
+    { LNILKEY, LNILVAL }
 };
 
 static const LUA_REG_TYPE wifi_mode_map[] = {
@@ -532,6 +533,7 @@ static const LUA_REG_TYPE wifi_mode_map[] = {
     { LSTRKEY( "AP"           ), LINTVAL( WIFI_MODE_AP ) },
     { LSTRKEY( "APSTA"        ), LINTVAL( WIFI_MODE_APSTA ) },
     { LSTRKEY( "STAENT"       ), LINTVAL( WIFI_MODE_STA_ENTERPRISE ) },
+    { LNILKEY, LNILVAL }
 };
 
 static const LUA_REG_TYPE wifi_powersave_map[] = {
@@ -539,18 +541,21 @@ static const LUA_REG_TYPE wifi_powersave_map[] = {
     { LSTRKEY( "MODEM"         ), LINTVAL( WIFI_PS_MIN_MODEM ) },
     { LSTRKEY( "MODEM_MIN"     ), LINTVAL( WIFI_PS_MIN_MODEM ) },
     { LSTRKEY( "MODEM_MAX"     ), LINTVAL( WIFI_PS_MAX_MODEM ) },
+    { LNILKEY, LNILVAL }
 };
 
 static const LUA_REG_TYPE wifi_wpstype_map[] = {
     { LSTRKEY( "DISABLE"       ), LINTVAL( WPS_TYPE_DISABLE ) },
     { LSTRKEY( "PBC"           ), LINTVAL( WPS_TYPE_PBC ) },
     { LSTRKEY( "PIN"           ), LINTVAL( WPS_TYPE_PIN ) },
+    { LNILKEY, LNILVAL }
 };
 
 static const LUA_REG_TYPE wifi_timecheck_map[] = {
     { LSTRKEY( "DEFAULT"       ), LINTVAL( 2 ) },
     { LSTRKEY( "ENABLE"        ), LINTVAL( 0 ) },
     { LSTRKEY( "DISABLE"       ), LINTVAL( 1 ) },
+    { LNILKEY, LNILVAL }
 };
 
 static const LUA_REG_TYPE wifi_map[] = {

--- a/components/lua/modules/sys/crc.c
+++ b/components/lua/modules/sys/crc.c
@@ -93,12 +93,7 @@ static const LUA_REG_TYPE crc_map[] =
 };
 
 int luaopen_crc(lua_State *L) {
-	#if !LUA_USE_ROTABLE
-	luaL_newlib(L, crc_map);
-	return 1;
-	#else
-	return 0;
-	#endif		   
+	LNEWLIB(L, crc_map);   
 }
 	   
 MODULE_REGISTER_ROM(CRC, crc, crc_map, luaopen_crc, 1);

--- a/components/lua/modules/sys/lpack.c
+++ b/components/lua/modules/sys/lpack.c
@@ -443,12 +443,7 @@ static const LUA_REG_TYPE pack_map[] =
 };
 
 int luaopen_pack(lua_State *L) {
-	#if !LUA_USE_ROTABLE
-	luaL_newlib(L, pack_map);
-	return 1;
-	#else
-	return 0;
-	#endif		   
+	LNEWLIB(L, pack_map);
 }
 	   
 MODULE_REGISTER_ROM(PACK, pack, pack_map, luaopen_pack, 1);

--- a/components/lua/modules/sys/md5.c
+++ b/components/lua/modules/sys/md5.c
@@ -118,12 +118,7 @@ static const LUA_REG_TYPE md5_map[] =
 };
 
 int luaopen_md5(lua_State *L) {
-#if !LUA_USE_ROTABLE
-    luaL_newlib(L, md5_map);
-    return 1;
-#else
-    return 0;
-#endif
+    LNEWLIB(L, md5_map);
 }
 
 MODULE_REGISTER_ROM(MD5, md5, md5_map, luaopen_md5, 1);

--- a/components/lua/modules/sys/nvs.c
+++ b/components/lua/modules/sys/nvs.c
@@ -408,12 +408,7 @@ static const LUA_REG_TYPE nvs_map[] =
 };
 
 int luaopen_nvs(lua_State *L) {
-    #if !LUA_USE_ROTABLE
-    luaL_newlib(L, nvs_map);
-    return 1;
-    #else
-    return 0;
-    #endif
+    LNEWLIB(L, nvs_map);
 }
    
 MODULE_REGISTER_ROM(NVS, nvs, nvs_map, luaopen_nvs, 1);

--- a/components/lua/modules/sys/vm.c
+++ b/components/lua/modules/sys/vm.c
@@ -78,6 +78,7 @@ static int llua_blocks(lua_State *L) {
 
 static const LUA_REG_TYPE lvm_map[] = {
   { LSTRKEY( "blocks" ), LFUNCVAL( llua_blocks    ) },
+  { LNILKEY, LNILVAL } 
 };
 
 LUALIB_API int luaopen_vm( lua_State *L ) {

--- a/components/lua/src/lbitlib.c
+++ b/components/lua/src/lbitlib.c
@@ -200,26 +200,25 @@ static int b_replace (lua_State *L) {
 
 
 static const luaL_Reg bitlib[] = {
-  {"arshift", b_arshift},
-  {"band", b_and},
-  {"bnot", b_not},
-  {"bor", b_or},
-  {"bxor", b_xor},
-  {"btest", b_test},
-  {"extract", b_extract},
-  {"lrotate", b_lrot},
-  {"lshift", b_lshift},
-  {"replace", b_replace},
-  {"rrotate", b_rrot},
-  {"rshift", b_rshift},
-  {NULL, NULL}
+  {LSTRKEY("arshift"),    LFUNCVAL( b_arshift)},
+  {LSTRKEY("band"),       LFUNCVAL( b_and)},
+  {LSTRKEY("bnot"),       LFUNCVAL( b_not)},
+  {LSTRKEY("bor"),        LFUNCVAL( b_or)},
+  {LSTRKEY("bxor"),       LFUNCVAL( b_xor)},
+  {LSTRKEY("btest"),      LFUNCVAL( b_test)},
+  {LSTRKEY("extract"),    LFUNCVAL( b_extract)},
+  {LSTRKEY("lrotate"),    LFUNCVAL( b_lrot)},
+  {LSTRKEY("lshift"),     LFUNCVAL( b_lshift)},
+  {LSTRKEY("replace"),    LFUNCVAL( b_replace)},
+  {LSTRKEY("rrotate"),    LFUNCVAL( b_rrot)},
+  {LSTRKEY("rshift"),     LFUNCVAL( b_rshift)},
+  {LNILKEY, LNILVAL }
 };
 
 
 
 LUAMOD_API int luaopen_bit32 (lua_State *L) {
-  luaL_newlib(L, bitlib);
-  return 1;
+  LNEWLIB(L, bitlib); 
 }
 
 

--- a/components/lua/src/lcorolib.c
+++ b/components/lua/src/lcorolib.c
@@ -164,12 +164,7 @@ static const LUA_REG_TYPE co_funcs[] = {
 
 
 LUAMOD_API int luaopen_coroutine (lua_State *L) {
-#if !LUA_USE_ROTABLE
-  luaL_newlib(L, co_funcs);
-  return 1;
-#else
-  return 0;
-#endif
+  LNEWLIB(L, co_funcs);
 }
 
 MODULE_REGISTER_ROM(COROUTINE, coroutine, co_funcs, luaopen_coroutine, 1);

--- a/components/lua/src/ldblib.c
+++ b/components/lua/src/ldblib.c
@@ -452,12 +452,7 @@ static const LUA_REG_TYPE dblib[] = {
 
 
 LUAMOD_API int luaopen_debug (lua_State *L) {
-#if !LUA_USE_ROTABLE
-  luaL_newlib(L, dblib);
-  return 1;
-#else
-  return 0;
-#endif
+  LNEWLIB(L, dblib);
 }
 
 MODULE_REGISTER_ROM(DEBUG, debug, dblib, luaopen_debug, 1);


### PR DESCRIPTION
This fix the crash in #353 

There is still an issue in the `#` operator returning wrong number of item in the rotable and the `pairs()` / `ipairs()` swrong behaviour, But we can live with it for now, using only `pairs()`