### PR TITLE
nvs.write(namespace, key, value) do not fully type check the value.

### DIFF
--- a/components/lua/modules/sys/nvs.c
+++ b/components/lua/modules/sys/nvs.c
@@ -81,7 +81,7 @@ static void nvs_error(lua_State* L, int code) {
     }
 }
 
-// Lua: nvs.write(namespace, key) return: nothing|exception
+// Lua: nvs.write(namespace, key, value) return: nothing|exception
 static int l_nvs_write(lua_State *L) {
     int total = lua_gettop(L); // Get number of arguments
     nvs_handle handle_to_settings;
@@ -185,7 +185,7 @@ static int l_nvs_write(lua_State *L) {
     return 0;
 }
 
-// Lua: nvs.rm(namespace, key) return: true|exception
+// Lua: nvs.read(namespace, key) return: boolean|exception
 static int l_nvs_read(lua_State *L) {
     int total = lua_gettop(L); // Get number of arguments
     nvs_handle handle_to_settings;

--- a/components/lua/modules/sys/nvs.c
+++ b/components/lua/modules/sys/nvs.c
@@ -155,6 +155,9 @@ static int l_nvs_write(lua_State *L) {
                 memcpy((char *)(val_val + 1), str_val, val_size - 1);
             }
             break;
+        default :
+            return luaL_error(L, "value of unsupported type");
+            break;
     }
 
     // Open


### PR DESCRIPTION
Using a value of type table make no error, but next attempt to `nvs.read()` or `nvs.exists()` throw a _not enough memory_ exception.

to reproduce: 
```lua
nvs.write('test','test', {} )
nvs.exists('test','test')
```

Please note to update the documentation [NVS module](https://github.com/whitecatboard/Lua-RTOS-ESP32/wiki/NVS-module)

```diff
diff --git a/NVS-module.md b/NVS-module.md
index 81826dc..324449a 100644
--- a/NVS-module.md
+++ b/NVS-module.md
@@ -41,7 +41,7 @@ Arguments:
 * namespace (string): the namespace to check the key-value pair existence.
 * key (string): the key name to to check.
 
-Returns: linked value, or an exception.
+Returns: a boolean indicating if the key exist or not.
 
 ```lua
 nvs.exists("settings","timeout")
@@ -56,7 +56,7 @@ Arguments:
 * namespace (string): the namespace where the key is.
 * key (string): the key name remove in namespace.
 
-Returns: a boolean indicating if the key has been removed (true), or an exception.
+Returns: a boolean indicating if the key has been removed (true), or not.
 
 ```lua
 nvs.rm("settings","timeout")

 
```