### PR TITLE
fix crash when calling stepper.stop() before stepper.start()

### DIFF
--- a/components/sys/drivers/stepper.c
+++ b/components/sys/drivers/stepper.c
@@ -631,7 +631,7 @@ void stepper_stop(int mask) {
 
     portEXIT_CRITICAL(&spinlock);
 
-    if (start_num == 0) {
+    if (waiting_task && start_num == 0) {
         xTaskNotifyGive(waiting_task);
     }
 }


### PR DESCRIPTION
Calling `stepper.stop()` crash and reboot when called before any `stepper.start(...)`

Step;
```lua
s1 = stepper.attach(pio.GPIO26, pio.GPIO14)
stepper.stop()
```
reboot the esp32

```

/ > stepper.stop()
/home/chowette/dev/esp-idf/components/freertos/tasks.c:4935 (xTaskNotify)- assert failed!
abort() was called at PC 0x4009a57d on core 0

ELF file SHA256: e2270b90484cd7b61cf915203b78492ac40a4a221c531a2fd389d72320a021e8

Backtrace: 0x400919df:0x3ffcfcb0 0x40091d21:0x3ffcfcd0 0x4009a57d:0x3ffcfcf0 0x4011a85b:0x3ffcfd10 0x4012844d:0x3ffcfd30 0x401435c7:0x3ffcfd50 0x401416e5:0x3ffcfd80 0x40143821:0x3ffcfdd0 0x40143841:0x3ffcfdf0 0x40143c29:0x3ffcfe10 0x401431ad:0x3ffcfe30 0x401439d0:0x3ffcfeb0 0x40144a95:0x3ffcfee0 0x4013c938:0x3ffcff10 0x4013cbee:0x3ffcff30 0x4013ce35:0x3ffcff60 0x401435c7:0x3ffcff90 0x4014381a:0x3ffcffc0 0x40143841:0x3ffcffe0 0x40143c29:0x3ffd0000 0x401431ad:0x3ffd0020 0x401439d0:0x3ffd00a0 0x40144a95:0x3ffd00d0 0x4013cba4:0x3ffd0100 0x4011261b:0x3ffd0130 0x40111c73:0x3ffd0150

Rebooting...

```

The reboot is triggered by the assert in the `xTaskNotifyGive()` because `waiting_task `is `NULL`
