### PR TITLE
stepper.stop() can be applied to some motor only.

### DIFF
--- a/components/lua/modules/hw/stepper.c
+++ b/components/lua/modules/hw/stepper.c
@@ -191,8 +191,40 @@ static int lstepper_start( lua_State* L ){
 }
 
 static int lstepper_stop( lua_State* L ) {
-    stepper_stop(0xffffffff);
+    stepper_userdata *lstepper = NULL;
+    int mask = 0;
+    int i;
 
+    if (lua_istable(L, 1)) {
+        lua_pushnil(L);
+        while (lua_next(L, 1) != 0) {
+            if (!lua_isnil(L, -1)) {
+                lstepper = (stepper_userdata *)luaL_checkudata(L, -1, "stepper.inst");
+                luaL_argcheck(L, lstepper, -1, "stepper expected");
+
+                mask |= (1 << (lstepper->unit));
+            }
+
+            lua_pop(L, 1);
+        }
+    } else {
+        int total = lua_gettop(L);
+
+        for (i=1; i <= total; i++) {
+            if (!lua_isnil(L, i)) {
+                lstepper = (stepper_userdata *)luaL_checkudata(L, i, "stepper.inst");
+                luaL_argcheck(L, lstepper, i, "stepper expected");
+
+                mask |= (1 << (lstepper->unit));
+            }
+        }
+    }
+
+    if (mask) {
+        stepper_stop(mask);
+    } else {
+        stepper_stop(0xffffffff);
+    }
     return 0;
 }
 


### PR DESCRIPTION
If steppers  are provided as a list of parameters or as a table ( like the `start()` function)