### PR TITLE
fixed typo in baud rate config

### DIFF
--- a/components/sys/Kconfig
+++ b/components/sys/Kconfig
@@ -225,8 +225,8 @@ menu "Lua RTOS"
          help
             Baud rate to use by the Lua RTOS console.
 
-      config LUA_RTOS_CONSOLE_BR_57200
-         bool "57200 baud"
+      config LUA_RTOS_CONSOLE_BR_57600
+         bool "57600 baud"
 
       config LUA_RTOS_CONSOLE_BR_115200
          bool "115200 baud"


### PR DESCRIPTION
changed LUA_RTOS_CONSOLE_BR_57200 to LUA_RTOS_CONSOLE_BR_57600 which is checked for in file components/sys/luartos.h

Sorry for the unclean diff, I have made the change using the github online editor which seems to have messed up something.